### PR TITLE
RTLSDR Gain Fixes & Other updates.

### DIFF
--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -12,7 +12,7 @@ def read_auto_rx_config(filename):
 	# Configuration Defaults:
 	auto_rx_config = {
 		'rtlsdr_ppm'	:	0,
-		'rtlsdr_gain'	:	0,
+		'rtlsdr_gain'	:	-1,
 		'rtlsdr_bias'	: False,
 		'search_attempts':	5,
 		'search_delay'	: 120,
@@ -21,6 +21,7 @@ def read_auto_rx_config(filename):
 		'search_step'	: 800,
 		'min_snr'		: 10,
 		'min_distance'	: 1000,
+		'dwell_time'	: 10,
 		'quantization'	: 10000,
 		'rx_timeout'	: 120,
 		'upload_rate'	: 30,
@@ -47,8 +48,8 @@ def read_auto_rx_config(filename):
 		config = ConfigParser.RawConfigParser()
 		config.read(filename)
 
-		auto_rx_config['rtlsdr_ppm'] = config.getint('rtlsdr', 'rtlsdr_ppm')
-		auto_rx_config['rtlsdr_gain'] = config.getint('rtlsdr', 'rtlsdr_gain')
+		auto_rx_config['rtlsdr_ppm'] = int(config.getfloat('rtlsdr', 'rtlsdr_ppm'))
+		auto_rx_config['rtlsdr_gain'] = config.getfloat('rtlsdr', 'rtlsdr_gain')
 		auto_rx_config['rtlsdr_bias'] = config.getboolean('rtlsdr', 'rtlsdr_bias')
 		auto_rx_config['search_attempts'] = config.getint('search_params', 'search_attempts')
 		auto_rx_config['search_delay'] = config.getint('search_params', 'search_delay')
@@ -57,6 +58,7 @@ def read_auto_rx_config(filename):
 		auto_rx_config['search_step'] = config.getfloat('search_params', 'search_step')
 		auto_rx_config['min_snr'] = config.getfloat('search_params', 'min_snr')
 		auto_rx_config['min_distance'] = config.getfloat('search_params', 'min_distance')
+		auto_rx_config['dwell_time'] = config.getint('search_params', 'dwell_time')
 		auto_rx_config['quantization'] = config.getint('search_params', 'quantization')
 		auto_rx_config['rx_timeout'] = config.getint('search_params', 'rx_timeout')
 		auto_rx_config['upload_rate'] = config.getint('upload', 'upload_rate')

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -6,28 +6,38 @@
 
 # Settings used when receiving data using a RTLSDR.
 [rtlsdr]
-# PPM Frequency Correction
+# PPM Frequency Correction (ppm offset)
+# Refer here for a method of determining this correction: https://gist.github.com/darksidelemm/b517e6a9b821c50c170f1b9b7d65b824
 rtlsdr_ppm = 0
-# Gain setting to use. 0 = Auto Gain
-rtlsdr_gain = 0
+# RTLSDR Gain Setting
+# Gain settings can generally range between 0dB and 30dB depending on the tuner in use.
+# Run rtl_test to confirm what gain settings are available, or use a value of -1 to use automatic gain control.
+# Note that this is an overall gain value, not an individual mixer/tuner gain. This is a limitation of the rtl_power/rtl_fm utils.
+rtlsdr_gain = -1
 # Enable RTLSDR Bias Tee (for v3 Dongles)
-# Requires rtl_biast be installed.
+# Requires a recent version of rtl-sdr to be installed (needs the -T option)
 rtlsdr_bias = False
 
 # Radiosonde Search Parameters
 [search_params]
+# Number of times to scan before quitting (Deprecated?)
 search_attempts = 10
-search_delay = 120
+# Wait time between failed scans.
+search_delay = 10
 
-# Minimum and maximum search frequencies, in MHz
+# Minimum and maximum search frequencies, in MHz.
+# Australia: Use 400.4 - 404 MHz
+# Europe: Use 400.5 - 406 MHz
 min_freq = 400.4
 max_freq = 404.0
-# Receive bin width, in Hz
+# Receive bin width (Hz)
 search_step = 800
 # Minimum SNR for a peak to be detected. The lower the number, the more peaks detected.
 min_snr = 10
-# Minimum distance between peaks
+# Minimum distance between peaks (Hz)
 min_distance = 1000
+# Dwell time - How long to wait for a sonde detection on each peak.
+dwell_time = 10
 # Quantize search results to x Hz steps. Useful as most sondes are on 10 kHz frequency steps. 
 quantization = 10000
 # Timeout and re-scan after X seconds of no data.

--- a/auto_rx/utils/plot_rtl_power.py
+++ b/auto_rx/utils/plot_rtl_power.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+#
+# auto_rx debug utils - Plot an rtl_power output file.
+#
+# Usage: python plot_rtl_power.py log_power.csv
+# Requires Numpy & Matplotlib
+#
+import matplotlib.pyplot as plt
+import numpy as np
+from StringIO import StringIO
+import sys
+
+# Need to keep this in sync with auto_rx.py as we're not set up to do relative imports yet.
+def read_rtl_power(filename):
+    """ Read in frequency samples from a single-shot log file produced by rtl_power """
+
+    # Output buffers.
+    freq = np.array([])
+    power = np.array([])
+
+    freq_step = 0
+
+
+    # Open file.
+    f = open(filename,'r')
+
+    # rtl_power log files are csv's, with the first 6 fields in each line describing the time and frequency scan parameters
+    # for the remaining fields, which contain the power samples. 
+
+    for line in f:
+        # Split line into fields.
+        fields = line.split(',')
+
+        if len(fields) < 6:
+            logging.error("Invalid number of samples in input file - corrupt?")
+            raise Exception("Invalid number of samples in input file - corrupt?")
+
+        start_date = fields[0]
+        start_time = fields[1]
+        start_freq = float(fields[2])
+        stop_freq = float(fields[3])
+        freq_step = float(fields[4])
+        n_samples = int(fields[5])
+
+        #freq_range = np.arange(start_freq,stop_freq,freq_step)
+        samples = np.loadtxt(StringIO(",".join(fields[6:])),delimiter=',')
+        freq_range = np.linspace(start_freq,stop_freq,len(samples))
+
+        # Add frequency range and samples to output buffers.
+        freq = np.append(freq, freq_range)
+        power = np.append(power, samples)
+
+    f.close()
+
+    # Sanitize power values, to remove the nan's that rtl_power puts in there occasionally.
+    power = np.nan_to_num(power)
+
+    return (freq, power, freq_step)
+
+
+if __name__ == '__main__':
+	filename = sys.argv[1]
+
+	(freq, power, freq_step) = read_rtl_power(filename)
+
+	plt.plot(freq/1e6, power)
+	plt.xlabel("Frequency (MHz)")
+	plt.ylabel("Power (dB?)")
+	plt.title("rtl_power output: %s" % filename)
+	plt.show()
+


### PR DESCRIPTION
- Fixed issues with rtlsdr_gain setting. Use a setting of -1 to get automatic gain control, otherwise specify the desired gain as a value in dB.
- Added the plot_rtl_power.py util in utils/ to assist with debugging these sorts of issues.
- Added a dwell_time parameter, which allows adjusting the time rs_detect sits on a frequency and tries to detect a sonde. Allows for speeding up scanning quite considerably. Needs more testing to determine a suitable default value.
- Added detection of OSX OS, which removes the '-k 30' option from the rtl_power call, as this isn't supported under the macports-provided timeout command. May need to look at a better way of handling this.
- Made the -f option quit if no sonde is detected on the supplied frequency.