### PR TITLE
Add White/Black/Grey-list functionality.

### DIFF
--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -7,6 +7,7 @@
 import ConfigParser
 import logging
 import traceback
+import json
 
 def read_auto_rx_config(filename):
 	# Configuration Defaults:
@@ -49,7 +50,10 @@ def read_auto_rx_config(filename):
 		'ozi_hostname'	: '127.0.0.1',
 		'ozi_port'		: 55681,
 		'payload_summary_enabled': False,
-		'payload_summary_port' : 55672
+		'payload_summary_port' : 55672,
+		'whitelist'	: [],
+		'blacklist'	: [],
+		'greylist'		: []
 	}
 
 	try:
@@ -95,6 +99,11 @@ def read_auto_rx_config(filename):
 		auto_rx_config['ozi_port'] = config.getint('oziplotter', 'ozi_port')
 		auto_rx_config['payload_summary_enabled'] = config.getboolean('oziplotter', 'payload_summary_enabled')
 		auto_rx_config['payload_summary_port'] = config.getint('oziplotter', 'payload_summary_port')
+
+		# Read in lists using a JSON parser.
+		auto_rx_config['whitelist'] = json.loads(config.get('search_params','whitelist'))
+		auto_rx_config['blacklist'] = json.loads(config.get('search_params','blacklist'))
+		auto_rx_config['greylist'] = json.loads(config.get('search_params','greylist'))
 
 		return auto_rx_config
 

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -26,10 +26,10 @@ search_attempts = 10
 search_delay = 10
 
 # Minimum and maximum search frequencies, in MHz.
-# Australia: Use 400.4 - 404 MHz
-# Europe: Use 400.5 - 406 MHz
-min_freq = 400.4
-max_freq = 404.0
+# Australia: Use 400.05 - 403 MHz
+# Europe: Use 400.05 - 406 MHz
+min_freq = 400.05
+max_freq = 403.0
 
 # Receive bin width (Hz)
 search_step = 800
@@ -44,6 +44,19 @@ quantization = 10000
 # Timeout and re-scan after X seconds of no data.
 rx_timeout = 120
 
+# Frequency Lists - These must be provided as JSON-compatible lists of floats, i.e. [400.50, 401.520, 403.200]
+
+# White-List - Add values to this list to *only* scan on these frequencies.
+# This is for when you only want to monitor a small set of launch frequencies.
+whitelist = []
+
+# Black-List - Any values added to this list will be removed from the list of detected peaks.
+# This is used to remove known spurs or other interferers from the scan list, potentially speeding up detection of a sonde.
+blacklist = []
+
+# Grey-List - Any values in this list will be added to every scan run.
+# This is useful when you know the regular frequency of a local sonde, but still want to allow detections on other frequencies.
+greylist = []
 
 # Station Location (optional). Used by the Habitat Uploader, and by Rotator Control
 [location]

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -38,13 +38,13 @@ min_snr = 10
 # Minimum distance between peaks (Hz)
 min_distance = 1000
 # Dwell time - How long to wait for a sonde detection on each peak.
-dwell_time = 10
+dwell_time = 5
 # Quantize search results to x Hz steps. Useful as most sondes are on 10 kHz frequency steps. 
 quantization = 10000
 # Timeout and re-scan after X seconds of no data.
 rx_timeout = 120
 
-# Frequency Lists - These must be provided as JSON-compatible lists of floats, i.e. [400.50, 401.520, 403.200]
+# Frequency Lists - These must be provided as JSON-compatible lists of floats (in MHz), i.e. [400.50, 401.520, 403.200]
 
 # White-List - Add values to this list to *only* scan on these frequencies.
 # This is for when you only want to monitor a small set of launch frequencies.


### PR DESCRIPTION
This change add in support for the user to supply the following frequency lists:
- White-List: Only scan on these supplied frequencies.
- Black-List: Remove the supplied frequencies from the list of detected peaks (i.e. to remove known spurs)
- Grey-List: Add the supplied frequencies to the start of each scan list, so they are checked prior to looking at other frequencies.

I've also removed the 'highpass 20' option from the RS41 demod call, as it appears to degrade performance.