### PR TITLE
Add position filtering, based on altitude and/or radius from listener.

### DIFF
--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -54,7 +54,9 @@ def read_auto_rx_config(filename):
 		'payload_summary_port' : 55672,
 		'whitelist'	: [],
 		'blacklist'	: [],
-		'greylist'	: []
+		'greylist'	: [],
+		'max_altitude'	: 50000,
+		'max_radius_km'	: 1000
 	}
 
 	try:
@@ -103,9 +105,13 @@ def read_auto_rx_config(filename):
 		auto_rx_config['payload_summary_port'] = config.getint('oziplotter', 'payload_summary_port')
 
 		# Read in lists using a JSON parser.
-		auto_rx_config['whitelist'] = json.loads(config.get('search_params','whitelist'))
-		auto_rx_config['blacklist'] = json.loads(config.get('search_params','blacklist'))
-		auto_rx_config['greylist'] = json.loads(config.get('search_params','greylist'))
+		auto_rx_config['whitelist'] = json.loads(config.get('search_params', 'whitelist'))
+		auto_rx_config['blacklist'] = json.loads(config.get('search_params', 'blacklist'))
+		auto_rx_config['greylist'] = json.loads(config.get('search_params', 'greylist'))
+
+		# Position Filtering
+		auto_rx_config['max_altitude'] = config.getint('filtering', 'max_altitude')
+		auto_rx_config['max_radius_km'] = config.getint('filtering', 'max_radius_km')
 
 		return auto_rx_config
 

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -141,3 +141,13 @@ ozi_port = 55681
 # Payload summary output, which can be used by a few of the Horus Ground Station tools
 payload_summary_enabled = False
 payload_summary_port = 55672
+
+# Position Filtering Options
+# These are used to discard positions which are clearly bad, such as where the payload has jumped halfway around the world,
+# or has suddenly ended up in orbit.
+# Adjust only if absolutely necessary.
+[filtering]
+# Discard positions with an altitude greater than 50000 metres. 
+max_altitude = 50000
+# Discard positions more than 1000 km from the observation station location (if set)
+max_radius_km = 1000


### PR DESCRIPTION
Add two position filtering options:
- Altitude cap - this will stop the payload jumping to absurd altitude when the GPS position glitches out.
- Radius cap - same as above, but based on radius from the station lat/lon (if set).