### PR TITLE
RS41 Temperature Support

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -583,7 +583,7 @@ def decode_rs41(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, timeout=12
     # Note: I've got the check-CRC option hardcoded in here as always on. 
     # I figure this is prudent if we're going to proceed to push this telemetry data onto a map.
 
-    decode_cmd += "./rs41ecc --crc --ecc " # if this doesn't work try -i at the end
+    decode_cmd += "./rs41ecc --crc --ecc --ptu" # if this doesn't work try -i at the end
 
     logging.debug("Running command: %s" % decode_cmd)
 

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -353,9 +353,6 @@ def check_position_valid(data):
 
 def process_rs_line(line):
     """ Process a line of output from the rs92gps decoder, converting it to a dict """
-    # Sample output:
-    #   0      1        2        3            4         5         6      7   8     9  10
-    # 106,M3553150,2017-04-30,05:44:40.460,-34.72471,138.69178,-263.83, 0.1,265.0,0.3,OK
     try:
 
         if line[0] != "{":
@@ -365,12 +362,15 @@ def process_rs_line(line):
         # Note: We expect the following fields available within the JSON blob:
         # id, frame, datetime, lat, lon, alt, crc
         rs_frame['crc'] = True # the rs92ecc only reports frames that match crc so we can lie here
-        rs_frame['temp'] = 0.0 #we don't have this yet
-        rs_frame['humidity'] = 0.0
+
+        if 'temp' not in rs_frame.keys():
+            rs_frame['temp'] = -273.0 # We currently don't get temperature data out of the RS92s.
+
+        rs_frame['humidity'] = -1.0 # Currently no Humidity data available.
         rs_frame['datetime_str'] = rs_frame['datetime'].replace("Z","") #python datetime sucks
         rs_frame['short_time'] = rs_frame['datetime'].split(".")[0].split("T")[1]
 
-        _telem_string = "%s,%d,%s,%.5f,%.5f,%.1f,%s" % (rs_frame['id'], rs_frame['frame'],rs_frame['datetime'], rs_frame['lat'], rs_frame['lon'], rs_frame['alt'], rs_frame['crc'])
+        _telem_string = "%s,%d,%s,%.5f,%.5f,%.1f,%.1f,%s" % (rs_frame['id'], rs_frame['frame'],rs_frame['datetime'], rs_frame['lat'], rs_frame['lon'], rs_frame['alt'], rs_frame['temp'], rs_frame['crc'])
 
         if check_position_valid(rs_frame):
             logging.info("TELEMETRY: %s" % _telem_string)
@@ -519,13 +519,14 @@ def decode_rs92(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, almanac=No
 
                             # Write a log line
                             # datetime,id,frame_no,lat,lon,alt,type,frequency
-                            _log_line = "%s,%s,%d,%.5f,%.5f,%.1f,%s,%.3f\n" % (
+                            _log_line = "%s,%s,%d,%.5f,%.5f,%.1f,%.1f,%s,%.3f\n" % (
                                 data['datetime_str'],
                                 data['id'],
                                 data['frame'],
                                 data['lat'],
                                 data['lon'],
                                 data['alt'],
+                                data['temp'],
                                 (data['type'] + _ozone),
                                 frequency/1e6)
 
@@ -621,13 +622,14 @@ def decode_rs41(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, timeout=12
 
                             # Write a log line
                             # datetime,id,frame_no,lat,lon,alt,type,frequency
-                            _log_line = "%s,%s,%d,%.5f,%.5f,%.1f,%s,%.3f\n" % (
+                            _log_line = "%s,%s,%d,%.5f,%.5f,%.1f,%.1f,%s,%.3f\n" % (
                                 data['datetime_str'],
                                 data['id'],
                                 data['frame'],
                                 data['lat'],
                                 data['lon'],
                                 data['alt'],
+                                data['temp'],
                                 data['type'],
                                 frequency/1e6)
 
@@ -693,6 +695,7 @@ def internet_push_thread(station_config):
                 aprs_comment = station_config['aprs_custom_comment']
                 aprs_comment = aprs_comment.replace("<freq>", data['freq'])
                 aprs_comment = aprs_comment.replace("<id>", data['id'])
+                aprs_comment = aprs_comment.replace("<temp>", "%.1f degC" % data['temp'])
                 aprs_comment = aprs_comment.replace("<vel_v>", "%.1fm/s" % data['vel_v'])
                 # Add 'Ozone' to the sonde type field if we are seeing aux data.
                 _sonde_type = data['type']

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -99,6 +99,7 @@ aprs_object_id = <id>
 # <type> - Sonde Type (RS94/RS41)
 # <id> - Sonde Serial Number (i.e. M1234567)
 # <vel_v> - Sonde Vertical Velocity (i.e. -5.1m/s)
+# <temp> - Sonde reported temperature. If no temp data available, this will report -273 degC. Only works for RS41s.
 aprs_custom_comment = Radiosonde Auto-RX <freq>
 
 # Settings for uploading to the Habitat HAB tracking database

--- a/demod/rs41dm_dft.c
+++ b/demod/rs41dm_dft.c
@@ -988,7 +988,13 @@ int print_position() {
             {
                 //fprintf(stdout, "  (%.1f %.1f %.1f) ", gpx.vN, gpx.vE, gpx.vU);
                 fprintf(stdout,"  vH: %4.1f  D: %5.1f°  vV: %3.1f ", gpx.vH, gpx.vD, gpx.vU);
-                printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+                if (!err1 && !err2 && !err3){
+                    if (option_ptu && !err0 && gpx.T > -273.0) {
+                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"temp\":\"%.1f\" }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.T );
+                    } else {
+                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+                    }
+                }
 
             }
         }

--- a/demod/rs41dm_dft.c
+++ b/demod/rs41dm_dft.c
@@ -990,7 +990,7 @@ int print_position() {
                 fprintf(stdout,"  vH: %4.1f  D: %5.1f°  vV: %3.1f ", gpx.vH, gpx.vD, gpx.vU);
                 if (!err1 && !err2 && !err3){
                     if (option_ptu && !err0 && gpx.T > -273.0) {
-                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"temp\":\"%.1f\" }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.T );
+                        printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"temp\":%.1f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.T );
                     } else {
                         printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
                     }

--- a/demod/rs92dm.c
+++ b/demod/rs92dm.c
@@ -1112,10 +1112,12 @@ int print_position() {  // GPS-Hoehe ueber Ellipsoid
             Gps2Date(gpx.week, gpx.gpssec, &gpx.jahr, &gpx.monat, &gpx.tag);
             //fprintf(stdout, "(W %d) ", gpx.week);
             fprintf(stdout, "(%04d-%02d-%02d) ", gpx.jahr, gpx.monat, gpx.tag);
-            if (gpx.aux[0] != 0 || gpx.aux[1] != 0 || gpx.aux[2] != 0 || gpx.aux[3] != 0) {
-                printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"aux\": \"%04x%04x%04x%04x\"}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU , gpx.aux[0], gpx.aux[1], gpx.aux[2], gpx.aux[3]);
-            } else {
-                printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+            if (!err1 && !err2){
+                if (gpx.aux[0] != 0 || gpx.aux[1] != 0 || gpx.aux[2] != 0 || gpx.aux[3] != 0) {
+                    printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"aux\": \"%04x%04x%04x%04x\"}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU , gpx.aux[0], gpx.aux[1], gpx.aux[2], gpx.aux[3]);
+                } else {
+                    printf("\n{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f }\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU );
+                }
             }
         }
         fprintf(stdout, "%s ", weekday[gpx.wday]);  // %04.1f: wenn sek >= 59.950, wird auf 60.0 gerundet


### PR DESCRIPTION
Add support for reading RS41 temperature values. 

Added better RS92 error checking.

These can be added to the APRS comment using the <temp> field.

If no temperature data is available, the field is set to -273 degrees C.