### PR TITLE
Add callsign per sonde option for habhub

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -723,7 +723,7 @@ def internet_push_thread(station_config):
                 
                 payload_callsign = config['payload_callsign']
                 if config['payload_callsign'] == "<id>":
-                    initPayloadDoc(data['id']) # it's fine for us to call this multiple times as initPayloadDoc keeps a cache for serial numbers it's created payloads for.
+                    initPayloadDoc(data['id'], config['payload_description']) # it's fine for us to call this multiple times as initPayloadDoc keeps a cache for serial numbers it's created payloads for.
                     payload_callsign = data['id']
 
                 # Create comment field.

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -21,6 +21,7 @@ import signal
 import Queue
 import subprocess
 import traceback
+import json
 from aprs_utils import *
 from habitat_utils import *
 from ozi_utils import *
@@ -63,7 +64,6 @@ flight_stats = {
 
 # Station config, we need to populate this with data from station.cfg
 config = {}
-
 
 def run_rtl_power(start, stop, step, filename="log_power.csv", dwell = 20, ppm = 0, gain = -1, bias = False):
     """ Run rtl_power, with a timeout"""
@@ -720,11 +720,17 @@ def internet_push_thread(station_config):
                     _ozone = "-Ozone"
                 else:
                     _ozone = ""
+                
+                payload_callsign = config['payload_callsign']
+                if config['payload_callsign'] == "<id>":
+                    initPayloadDoc(data['id']) # it's fine for us to call this multiple times as initPayloadDoc keeps a cache for serial numbers it's created payloads for.
+                    payload_callsign = data['id']
+
                 # Create comment field.
                 habitat_comment = "%s%s %s %s" % (data['type'], _ozone, data['id'], data['freq'])
 
                 habitat_upload_payload_telemetry(data, 
-                                                payload_callsign=config['payload_callsign'], 
+                                                payload_callsign=payload_callsign, 
                                                 callsign=config['uploader_callsign'], 
                                                 comment=habitat_comment)
                 logging.debug("Data pushed to Habitat.")

--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -38,6 +38,7 @@ def read_auto_rx_config(filename):
 		'aprs_object_id': '<id>',
 		'aprs_custom_comment': 'Radiosonde Auto-RX <freq>',
 		'payload_callsign': 'RADIOSONDE',
+		'payload_description': 'Meteorology Radiosonde',
 		'uploader_callsign': 'SONDE_AUTO_RX',
 		'upload_listener_position': False,
 		'enable_rotator': False,
@@ -60,7 +61,7 @@ def read_auto_rx_config(filename):
 	}
 
 	try:
-		config = ConfigParser.RawConfigParser()
+		config = ConfigParser.RawConfigParser(auto_rx_config)
 		config.read(filename)
 
 		auto_rx_config['per_sonde_log'] = config.getboolean('logging', 'per_sonde_log')
@@ -89,6 +90,7 @@ def read_auto_rx_config(filename):
 		auto_rx_config['aprs_object_id'] = config.get('aprs', 'aprs_object_id')
 		auto_rx_config['aprs_custom_comment'] = config.get('aprs', 'aprs_custom_comment')
 		auto_rx_config['payload_callsign'] = config.get('habitat', 'payload_callsign')
+		auto_rx_config['payload_description'] = config.get('habitat', 'payload_description')
 		auto_rx_config['uploader_callsign'] = config.get('habitat', 'uploader_callsign')
 		auto_rx_config['upload_listener_position'] = config.getboolean('habitat','upload_listener_position')
 		auto_rx_config['enable_rotator'] = config.getboolean('rotator','enable_rotator')

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -96,7 +96,7 @@ payload_config_cache = {}
 def ISOStringNow():
     return "%sZ" % datetime.datetime.utcnow().isoformat()
 
-def initPayloadDoc(serial):
+def initPayloadDoc(serial, description="Meteorology Radiosonde", frequency=401500000):
     """Creates a payload in Habitat for the radiosonde before uploading"""
     global url_habitat_db
     global payload_config_cache 
@@ -109,11 +109,11 @@ def initPayloadDoc(serial):
         "name": serial,
         "time_created": ISOStringNow(),
         "metadata": { 
-             "description": "Bureau of Met Radiosonde, Melbourne, Second Launch"
+             "description": description
         },
         "transmissions": [
             {
-                "frequency": 401500000, #We might be able to fill this in at a later stage
+                "frequency": frequency, #We might be able to fill this in at a later stage
                 "modulation": "RTTY",
                 "mode": "USB",
                 "encoding": "ASCII-8",

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -90,9 +90,114 @@ url_habitat_uuids = "http://habitat.habhub.org/_uuids?count=%d"
 url_habitat_db = "http://habitat.habhub.org/habitat/"
 uuids = []
 
+# Keep an internal cache for which payload docs we've created so we don't spam couchdb with updates
+payload_config_cache = {}
+
 def ISOStringNow():
     return "%sZ" % datetime.datetime.utcnow().isoformat()
 
+def initPayloadDoc(serial):
+    """Creates a payload in Habitat for the radiosonde before uploading"""
+    global url_habitat_db
+    global payload_config_cache 
+    
+    if serial in payload_config_cache:
+        return payload_config_cache["serial"]
+
+    payload_data = {
+        "type": "payload_configuration",
+        "name": serial,
+        "time_created": ISOStringNow(),
+        "metadata": { 
+             "description": "Bureau of Met Radiosonde, Melbourne, Second Launch"
+        },
+        "transmissions": [
+            {
+                "frequency": 401500000, #We might be able to fill this in at a later stage
+                "modulation": "RTTY",
+                "mode": "USB",
+                "encoding": "ASCII-8",
+                "parity": "none",
+                "stop": 2,
+                "shift": 350,
+                "baud": 50,
+                "description": "DUMMY ENTRY, DATA IS VIA radiosonde_auto_rx"
+            }
+        ],
+        "sentences": [
+            {
+                "protocol": "UKHAS",
+                "callsign": serial,
+                "checksum":"crc16-ccitt",
+                "fields":[
+                    {
+                        "name": "sentence_id",
+                        "sensor": "base.ascii_int"
+                    },
+                    {
+                        "name": "time",
+                        "sensor": "stdtelem.time"
+                    }, 
+                    {
+                        "name": "latitude",
+                        "sensor": "stdtelem.coordinate",
+                        "format": "dd.dddd"
+                    },
+                    {
+                        "name": "longitude",
+                        "sensor": "stdtelem.coordinate",
+                        "format": "dd.dddd"
+                    },
+                    {
+                        "name": "altitude",
+                        "sensor": "base.ascii_int"
+                    },
+                    {
+                        "name": "speed",
+                        "sensor": "base.ascii_float"
+                    },
+                    {
+                        "name": "temperature_external",
+                        "sensor": "base.ascii_float"
+                    },
+                    {
+                        "name": "humidity",
+                        "sensor": "base.ascii_float"
+                    },
+                    {
+                        "name": "comment",
+                        "sensor": "base.string"
+                    }
+                ],
+            "filters": 
+                {
+                    "post": [
+                        {
+                            "filter": "common.invalid_location_zero",
+                            "type": "normal"
+                        }
+                    ]
+                },
+             "description": "radiosonde_auto_rx to Habitat Bridge"
+            }
+        ]
+    }
+    
+
+    data = json.dumps(payload_data)
+    headers = {
+            'Content-Type': 'application/json; charset=utf-8'
+            }
+
+    req = urllib2.Request(url_habitat_db, data, headers)
+    response = json.loads(urllib2.urlopen(req).read())
+    if response['ok'] == True:
+        logging.debug("Habitat Listener: Created a payload document for %s" % serial)
+        payload_config_cache = response
+    else:
+        logging.error("Habitat Listener: Failed to create a payload document for %s" % serial)
+        logging.error(response)
+    return response
 
 def postListenerData(doc):
     global uuids, url_habitat_db

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -112,6 +112,7 @@ aprs_custom_comment = Radiosonde Auto-RX <freq>
 [habitat]
 # Payload callsign - if set to <id> will use the serial number of the sonde and create a payload document automatically
 payload_callsign = <id>
+payload_description = "Meteorology Radiosonde"
 # Uploader callsign, as shown above.
 uploader_callsign = SONDE_AUTO_RX
 # Upload listener position to Habitat? (So you show up on the map)

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -110,8 +110,8 @@ aprs_custom_comment = Radiosonde Auto-RX <freq>
 # You will need to create an appropriate Habitat payload document for this data to appear on the habitat tracker.
 # 
 [habitat]
-# Payload callsign
-payload_callsign = RADIOSONDE
+# Payload callsign - if set to <id> will use the serial number of the sonde and create a payload document automatically
+payload_callsign = <id>
 # Uploader callsign, as shown above.
 uploader_callsign = SONDE_AUTO_RX
 # Upload listener position to Habitat? (So you show up on the map)


### PR DESCRIPTION
This creates a new payload document per radiosonde based off the serial number. This has been tested with RS41 but not the RS92

Fixes #32