### PR TITLE
MQTT support

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -509,6 +509,7 @@ def decode_rs92(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, almanac=No
 
                         # post to MQTT
                         if mqtt_client:
+                            data['seen_by'] = config['uploader_callsign']
                             mqtt_client.publish("sonde/%s" % data['id'], payload=json.dumps(data), retain=True)
 
                         # Per-Sonde Logging
@@ -623,6 +624,7 @@ def decode_rs41(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, timeout=12
 
                         # post to MQTT
                         if mqtt_client:
+                            data['seen_by'] = config['uploader_callsign']
                             mqtt_client.publish("sonde/%s" % data['id'], payload=json.dumps(data), retain=True)
 
                         # Per-Sonde Logging

--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -108,9 +108,6 @@ def read_auto_rx_config(filename):
 		auto_rx_config['ozi_port'] = config.getint('oziplotter', 'ozi_port')
 		auto_rx_config['payload_summary_enabled'] = config.getboolean('oziplotter', 'payload_summary_enabled')
 		auto_rx_config['payload_summary_port'] = config.getint('oziplotter', 'payload_summary_port')
-		auto_rx_config['mqtt_enabled'] = config.getboolean('mqtt', 'mqtt_enabled')
-		auto_rx_config['mqtt_hostname'] = config.get('mqtt', 'mqtt_hostname')
-		auto_rx_config['mqtt_port'] = config.getint('mqtt', 'mqtt_port')
 
 		# Read in lists using a JSON parser.
 		auto_rx_config['whitelist'] = json.loads(config.get('search_params', 'whitelist'))
@@ -120,6 +117,11 @@ def read_auto_rx_config(filename):
 		# Position Filtering
 		auto_rx_config['max_altitude'] = config.getint('filtering', 'max_altitude')
 		auto_rx_config['max_radius_km'] = config.getint('filtering', 'max_radius_km')
+
+		# MQTT settings
+		auto_rx_config['mqtt_enabled'] = config.getboolean('mqtt', 'mqtt_enabled')
+		auto_rx_config['mqtt_hostname'] = config.get('mqtt', 'mqtt_hostname')
+		auto_rx_config['mqtt_port'] = config.getint('mqtt', 'mqtt_port')
 
 		return auto_rx_config
 

--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -51,6 +51,9 @@ def read_auto_rx_config(filename):
 		'ozi_update_rate': 5,
 		'ozi_hostname'	: '127.0.0.1',
 		'ozi_port'		: 55681,
+		'mqtt_enabled'	: False,
+		'mqtt_hostname'	: '127.0.0.1',
+		'mqtt_port'		: 1883,
 		'payload_summary_enabled': False,
 		'payload_summary_port' : 55672,
 		'whitelist'	: [],
@@ -105,6 +108,9 @@ def read_auto_rx_config(filename):
 		auto_rx_config['ozi_port'] = config.getint('oziplotter', 'ozi_port')
 		auto_rx_config['payload_summary_enabled'] = config.getboolean('oziplotter', 'payload_summary_enabled')
 		auto_rx_config['payload_summary_port'] = config.getint('oziplotter', 'payload_summary_port')
+		auto_rx_config['mqtt_enabled'] = config.getboolean('mqtt', 'mqtt_enabled')
+		auto_rx_config['mqtt_hostname'] = config.get('mqtt', 'mqtt_hostname')
+		auto_rx_config['mqtt_port'] = config.getint('mqtt', 'mqtt_port')
 
 		# Read in lists using a JSON parser.
 		auto_rx_config['whitelist'] = json.loads(config.get('search_params', 'whitelist'))

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -153,3 +153,10 @@ payload_summary_port = 55672
 max_altitude = 50000
 # Discard positions more than 1000 km from the observation station location (if set)
 max_radius_km = 1000
+
+# MQTT
+# Post all sonde messages to a MQTT server
+[mqtt]
+mqtt_enabled = False
+mqtt_hostname = 127.0.0.1
+mqtt_port = 1883


### PR DESCRIPTION
Adds optional support for dumping sonde packets to a MQTT server. Uses `paho-mqtt` library but it isn't imported unless it is enabled in the config, so you won't need to install it if you're not using it.
  