### PR TITLE
Multiple Updates - APRS Server Selection + some preliminary work to allow experiments with other RX utilities

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -37,7 +37,7 @@ from async_file_reader import AsynchronousFileReader
 # Logging level
 # INFO = Basic status messages
 # DEBUG = Adds information on each command run by subprocess.
-logging_level = logging.DEBUG
+logging_level = logging.INFO
 
 # Set this to true to enable dumping of all the rtl_power output to files in ./log/
 # Note that this can result in a LOT of log files being generated depending on your scanning settings.

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -733,7 +733,8 @@ def internet_push_thread(station_config):
                                                 object_name=station_config['aprs_object_id'],
                                                 aprs_comment=aprs_comment,
                                                 aprsUser=station_config['aprs_user'],
-                                                aprsPass=station_config['aprs_pass'])
+                                                aprsPass=station_config['aprs_pass'],
+                                                serverHost=station_config['aprs_server'])
                 logging.info("Data pushed to APRS-IS: %s" % aprs_data)
 
             # Habitat Upload

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -715,7 +715,7 @@ def internet_push_thread(station_config):
         try:
             # Wrap this entire section in a try/except, to catch any data parsing errors.
             # APRS Upload
-            if station_config['enable_aprs']:
+            if station_config['enable_aprs'] and (data['lat'] != 0.0) and (data['lon'] != 0.0):
                 # Produce aprs comment, based on user config.
                 aprs_comment = station_config['aprs_custom_comment']
                 aprs_comment = aprs_comment.replace("<freq>", data['freq'])

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -37,7 +37,7 @@ from async_file_reader import AsynchronousFileReader
 # Logging level
 # INFO = Basic status messages
 # DEBUG = Adds information on each command run by subprocess.
-logging_level = logging.INFO
+logging_level = logging.DEBUG
 
 # Set this to true to enable dumping of all the rtl_power output to files in ./log/
 # Note that this can result in a LOT of log files being generated depending on your scanning settings.
@@ -66,7 +66,7 @@ flight_stats = {
 # Station config, we need to populate this with data from station.cfg
 config = {}
 
-def run_rtl_power(start, stop, step, filename="log_power.csv", dwell = 20, ppm = 0, gain = -1, bias = False):
+def run_rtl_power(start, stop, step, filename="log_power.csv", dwell = 20, sdr_power='rtl_power', ppm = 0, gain = -1, bias = False):
     """ Run rtl_power, with a timeout"""
     # Example: rtl_power -T -f 400400000:403500000:800 -i20 -1 -c 20% -p 0 -g 26.0 log_power.csv
 
@@ -87,7 +87,7 @@ def run_rtl_power(start, stop, step, filename="log_power.csv", dwell = 20, ppm =
     else:
         timeout_kill = '-k 30 '
 
-    rtl_power_cmd = "timeout %s%d rtl_power %s-f %d:%d:%d -i %d -1 -c 20%% -p %d %s%s" % (timeout_kill, dwell+10, bias_option, start, stop, step, dwell, int(ppm), gain_param, filename)
+    rtl_power_cmd = "timeout %s%d %s %s-f %d:%d:%d -i %d -1 -c 20%% -p %d %s%s" % (timeout_kill, dwell+10, sdr_power, bias_option, start, stop, step, dwell, int(ppm), gain_param, filename)
     logging.info("Running frequency scan.")
     logging.debug("Running command: %s" % rtl_power_cmd)
     ret_code = os.system(rtl_power_cmd)
@@ -148,7 +148,7 @@ def quantize_freq(freq_list, quantize=5000):
     """ Quantise a list of frequencies to steps of <quantize> Hz """
     return np.round(freq_list/quantize)*quantize
 
-def detect_sonde(frequency, ppm=0, gain=-1, bias=False, dwell_time=10):
+def detect_sonde(frequency, sdr_fm='rtl_fm', ppm=0, gain=-1, bias=False, dwell_time=10):
     """ Receive some FM and attempt to detect the presence of a radiosonde. """
 
     # Example command (for command-line testing):
@@ -163,7 +163,7 @@ def detect_sonde(frequency, ppm=0, gain=-1, bias=False, dwell_time=10):
     else:
         gain_param = ''
 
-    rx_test_command = "timeout %ds rtl_fm %s-p %d %s-M fm -F9 -s 15k -f %d 2>/dev/null |" % (dwell_time, bias_option, int(ppm), gain_param, frequency) 
+    rx_test_command = "timeout %ds %s %s-p %d %s-M fm -F9 -s 15k -f %d 2>/dev/null |" % (dwell_time, sdr_fm, bias_option, int(ppm), gain_param, frequency) 
     rx_test_command += "sox -t raw -r 15k -e s -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null |"
     rx_test_command += "./rs_detect -z -t 8 2>/dev/null"
 
@@ -228,7 +228,7 @@ def sonde_search(config, attempts = 5):
 
         if len(config['whitelist']) == 0 :
             # No whitelist frequencies provided - perform a scan.
-            run_rtl_power(config['min_freq']*1e6, config['max_freq']*1e6, config['search_step'], ppm=config['rtlsdr_ppm'], gain=config['rtlsdr_gain'], bias=config['rtlsdr_bias'])
+            run_rtl_power(config['min_freq']*1e6, config['max_freq']*1e6, config['search_step'], sdr_power=config['sdr_power_path'], ppm=config['sdr_ppm'], gain=config['sdr_gain'], bias=config['sdr_bias'])
 
             # Read in result
             try:
@@ -296,10 +296,11 @@ def sonde_search(config, attempts = 5):
 
         # Run rs_detect on each peak frequency, to determine if there is a sonde there.
         for freq in peak_frequencies:
-            detected = detect_sonde(freq, 
-                ppm=config['rtlsdr_ppm'], 
-                gain=config['rtlsdr_gain'], 
-                bias=config['rtlsdr_bias'], 
+            detected = detect_sonde(freq,
+                sdr_fm=config['sdr_fm_path'], 
+                ppm=config['sdr_ppm'], 
+                gain=config['sdr_gain'], 
+                bias=config['sdr_bias'], 
                 dwell_time=config['dwell_time'])
             if detected != None:
                 sonde_freq = freq
@@ -436,7 +437,7 @@ def calculate_flight_statistics():
 
     return stats_str
 
-def decode_rs92(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, almanac=None, ephemeris=None, timeout=120, save_log=False):
+def decode_rs92(frequency, sdr_fm='rtl_fm', ppm=0, gain=-1, bias=False, rx_queue=None, almanac=None, ephemeris=None, timeout=120, save_log=False):
     """ Decode a RS92 sonde """
     global latest_sonde_data, internet_push_queue, ozi_push_queue
 
@@ -467,7 +468,7 @@ def decode_rs92(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, almanac=No
 
     # Example command:
     # rtl_fm -p 0 -g 26.0 -M fm -F9 -s 12k -f 400500000 | sox -t raw -r 12k -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 lowpass 2500 2>/dev/null | ./rs92ecc
-    decode_cmd = "rtl_fm %s-p %d %s-M fm -F9 -s 12k -f %d 2>/dev/null |" % (bias_option, int(ppm), gain_param, frequency)
+    decode_cmd = "%s %s-p %d %s-M fm -F9 -s 12k -f %d 2>/dev/null |" % (sdr_fm,bias_option, int(ppm), gain_param, frequency)
     decode_cmd += "sox -t raw -r 12k -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - lowpass 2500 highpass 20 2>/dev/null |"
 
     # Note: I've got the check-CRC option hardcoded in here as always on. 
@@ -577,7 +578,7 @@ def decode_rs92(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, almanac=No
     return
 
 
-def decode_rs41(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, timeout=120, save_log=False):
+def decode_rs41(frequency, sdr_fm='rtl_fm', ppm=0, gain=-1, bias=False, rx_queue=None, timeout=120, save_log=False):
     """ Decode a RS41 sonde """
     global latest_sonde_data, internet_push_queue, ozi_push_queue
     # Add a -T option if bias is enabled
@@ -591,7 +592,7 @@ def decode_rs41(frequency, ppm=0, gain=-1, bias=False, rx_queue=None, timeout=12
 
     # rtl_fm -p 0 -g -1 -M fm -F9 -s 15k -f 405500000 | sox -t raw -r 15k -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - lowpass 2600 2>/dev/null | ./rs41ecc
     # Note: Have removed a 'highpass 20' filter from the sox line, will need to re-evaluate if adding that is useful in the future.
-    decode_cmd = "rtl_fm %s-p %d %s-M fm -F9 -s 15k -f %d 2>/dev/null |" % (bias_option, int(ppm), gain_param, frequency)
+    decode_cmd = "%s %s-p %d %s-M fm -F9 -s 15k -f %d 2>/dev/null |" % (sdr_fm, bias_option, int(ppm), gain_param, frequency)
     decode_cmd += "sox -t raw -r 15k -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - lowpass 2600 2>/dev/null |"
 
     # Note: I've got the check-CRC option hardcoded in here as always on. 
@@ -883,7 +884,7 @@ if __name__ == "__main__":
         while time.time() < timeout_time or args.timeout == 0:
             # Attempt to detect a sonde on a supplied frequency.
             if args.frequency != 0.0:
-                sonde_type = detect_sonde(int(float(args.frequency)*1e6), ppm=config['rtlsdr_ppm'], gain=config['rtlsdr_gain'], bias=config['rtlsdr_bias'])
+                sonde_type = detect_sonde(int(float(args.frequency)*1e6), sdr_fm=config['sdr_fm_path'], ppm=config['sdr_ppm'], gain=config['sdr_gain'], bias=config['sdr_bias'])
                 if sonde_type != None:
                     sonde_freq = int(float(args.frequency)*1e6)
                 else:
@@ -923,18 +924,20 @@ if __name__ == "__main__":
             # Start decoding the sonde!
             if sonde_type == "RS92":
                 decode_rs92(sonde_freq, 
-                            ppm=config['rtlsdr_ppm'], 
-                            gain=config['rtlsdr_gain'], 
-                            bias=config['rtlsdr_bias'], 
+                            sdr_fm=config['sdr_fm_path'],
+                            ppm=config['sdr_ppm'], 
+                            gain=config['sdr_gain'], 
+                            bias=config['sdr_bias'], 
                             rx_queue=internet_push_queue, 
                             timeout=config['rx_timeout'], 
                             save_log=config['per_sonde_log'], 
                             ephemeris=ephemeris)
             elif sonde_type == "RS41":
                 decode_rs41(sonde_freq, 
-                            ppm=config['rtlsdr_ppm'], 
-                            gain=config['rtlsdr_gain'], 
-                            bias=config['rtlsdr_bias'], 
+                            sdr_fm=config['sdr_fm_path'],
+                            ppm=config['sdr_ppm'], 
+                            gain=config['sdr_gain'], 
+                            bias=config['sdr_bias'], 
                             rx_queue=internet_push_queue, 
                             timeout=config['rx_timeout'], 
                             save_log=config['per_sonde_log'])
@@ -955,6 +958,9 @@ if __name__ == "__main__":
         # Kill all rtl_fm processes.
         os.system('killall rtl_power')
         os.system('killall rtl_fm')
+        #.. and the rx_tools equivalents, just in case.
+        os.system('killall rx_power')
+        os.system('killall rx_fm')
         sys.exit(0)
     # Note that if we are running as a service, we won't ever get here.
 

--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -13,9 +13,11 @@ def read_auto_rx_config(filename):
 	# Configuration Defaults:
 	auto_rx_config = {
 		'per_sonde_log' : True,
-		'rtlsdr_ppm'	:	0,
-		'rtlsdr_gain'	:	-1,
-		'rtlsdr_bias'	: False,
+		'sdr_fm_path': 'rtl_fm',
+		'sdr_power_path': 'rtl_power',
+		'sdr_ppm'	:	0,
+		'sdr_gain'	:	-1,
+		'sdr_bias'	: False,
 		'search_attempts':	5,
 		'search_delay'	: 10,
 		'min_freq'		: 400.4,
@@ -68,9 +70,11 @@ def read_auto_rx_config(filename):
 		config.read(filename)
 
 		auto_rx_config['per_sonde_log'] = config.getboolean('logging', 'per_sonde_log')
-		auto_rx_config['rtlsdr_ppm'] = int(config.getfloat('rtlsdr', 'rtlsdr_ppm'))
-		auto_rx_config['rtlsdr_gain'] = config.getfloat('rtlsdr', 'rtlsdr_gain')
-		auto_rx_config['rtlsdr_bias'] = config.getboolean('rtlsdr', 'rtlsdr_bias')
+		auto_rx_config['sdr_fm_path'] = config.get('sdr','sdr_fm_path')
+		auto_rx_config['sdr_power_path'] = config.get('sdr','sdr_power_path')
+		auto_rx_config['sdr_ppm'] = int(config.getfloat('sdr', 'sdr_ppm'))
+		auto_rx_config['sdr_gain'] = config.getfloat('sdr', 'sdr_gain')
+		auto_rx_config['sdr_bias'] = config.getboolean('sdr', 'sdr_bias')
 		auto_rx_config['search_attempts'] = config.getint('search_params', 'search_attempts')
 		auto_rx_config['search_delay'] = config.getint('search_params', 'search_delay')
 		auto_rx_config['min_freq'] = config.getfloat('search_params', 'min_freq')

--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -37,6 +37,7 @@ def read_auto_rx_config(filename):
 		'enable_habitat': False,
 		'aprs_user'		: 'N0CALL',
 		'aprs_pass'		: '00000',
+		'aprs_server'	: 'rotate.aprs2.net',
 		'aprs_object_id': '<id>',
 		'aprs_custom_comment': 'Radiosonde Auto-RX <freq>',
 		'payload_callsign': '<id>',
@@ -94,6 +95,7 @@ def read_auto_rx_config(filename):
 		auto_rx_config['enable_habitat'] = config.getboolean('upload', 'enable_habitat')
 		auto_rx_config['aprs_user'] = config.get('aprs', 'aprs_user')
 		auto_rx_config['aprs_pass'] = config.get('aprs', 'aprs_pass')
+		auto_rx_config['aprs_server'] = config.get('aprs', 'aprs_server')
 		auto_rx_config['aprs_object_id'] = config.get('aprs', 'aprs_object_id')
 		auto_rx_config['aprs_custom_comment'] = config.get('aprs', 'aprs_custom_comment')
 		auto_rx_config['payload_callsign'] = config.get('habitat', 'payload_callsign')

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -9,19 +9,30 @@
 # If enabled, a log file will be written for each detected radiosonde.
 per_sonde_log = True
 
-# Settings used when receiving data using a RTLSDR.
-[rtlsdr]
+# SDR Receiver Settings
+[sdr]
+# Paths to the rtl_fm and rtl_power utilities, or their rx_tools equivalents.
+# RTLSDR (Default)
+sdr_fm_path = rtl_fm
+sdr_power_path = rtl_power
+
+# AirSpy
+#sdr_fm_path = rx_fm -d="driver=airspy"
+#sdr_power_path = rx_power -d="driver=airspy"
+
 # PPM Frequency Correction (ppm offset)
 # Refer here for a method of determining this correction: https://gist.github.com/darksidelemm/b517e6a9b821c50c170f1b9b7d65b824
-rtlsdr_ppm = 0
-# RTLSDR Gain Setting
+sdr_ppm = 0
+# SDR Gain Setting
 # Gain settings can generally range between 0dB and 30dB depending on the tuner in use.
 # Run rtl_test to confirm what gain settings are available, or use a value of -1 to use automatic gain control.
 # Note that this is an overall gain value, not an individual mixer/tuner gain. This is a limitation of the rtl_power/rtl_fm utils.
-rtlsdr_gain = -1
+sdr_gain = -1
 # Enable RTLSDR Bias Tee (for v3 Dongles)
+# WARNING: THIS ONLY WORKS WITH rtl_fm AND rtl_power
+# To enable the bias tee on other SDRs, consult the relevant SoapySDR Module documentation
 # Requires a recent version of rtl-sdr to be installed (needs the -T option)
-rtlsdr_bias = False
+sdr_bias = False
 
 # Radiosonde Search Parameters
 [search_params]

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -6,31 +6,24 @@
 
 # Logging Settings
 [logging]
-# If enabled, a log file will be written for each detected radiosonde.
+# If enabled, a log file will be written to ./log/ for each detected radiosonde.
 per_sonde_log = True
 
 # SDR Receiver Settings
 [sdr]
-# Paths to the rtl_fm and rtl_power utilities, or their rx_tools equivalents.
-# RTLSDR (Default)
+# Paths to the rtl_fm and rtl_power utilities. If these are on your system path, then you don't need to change this.
 sdr_fm_path = rtl_fm
 sdr_power_path = rtl_power
 
-# AirSpy
-#sdr_fm_path = rx_fm -d="driver=airspy"
-#sdr_power_path = rx_power -d="driver=airspy"
-
 # PPM Frequency Correction (ppm offset)
-# Refer here for a method of determining this correction: https://gist.github.com/darksidelemm/b517e6a9b821c50c170f1b9b7d65b824
+#   Refer here for a method of determining this correction: https://gist.github.com/darksidelemm/b517e6a9b821c50c170f1b9b7d65b824
 sdr_ppm = 0
 # SDR Gain Setting
-# Gain settings can generally range between 0dB and 30dB depending on the tuner in use.
-# Run rtl_test to confirm what gain settings are available, or use a value of -1 to use automatic gain control.
-# Note that this is an overall gain value, not an individual mixer/tuner gain. This is a limitation of the rtl_power/rtl_fm utils.
+#   Gain settings can generally range between 0dB and 30dB depending on the tuner in use.
+#   Run rtl_test to confirm what gain settings are available, or use a value of -1 to use automatic gain control.
+#   Note that this is an overall gain value, not an individual mixer/tuner gain. This is a limitation of the rtl_power/rtl_fm utils.
 sdr_gain = -1
 # Enable RTLSDR Bias Tee (for v3 Dongles)
-# WARNING: THIS ONLY WORKS WITH rtl_fm AND rtl_power
-# To enable the bias tee on other SDRs, consult the relevant SoapySDR Module documentation
 # Requires a recent version of rtl-sdr to be installed (needs the -T option)
 sdr_bias = False
 
@@ -70,7 +63,7 @@ whitelist = []
 # This is used to remove known spurs or other interferers from the scan list, potentially speeding up detection of a sonde.
 blacklist = []
 
-# Grey-List - Any values in this list will be added to every scan run.
+# Grey-List - Any values in this list will be added to the start every scan run.
 # This is useful when you know the regular frequency of a local sonde, but still want to allow detections on other frequencies.
 greylist = []
 
@@ -87,6 +80,7 @@ upload_rate = 30
 
 # Enable upload to various services.
 #  Uploading to APRS. Change settings in [aprs] block below.
+#  PLEASE READ WARNING HERE BEFORE ENABLING: https://github.com/projecthorus/radiosonde_auto_rx/wiki/Configuration-Settings#uploading-to-aprs-is
 enable_aprs = False
 #  Uploading to Habitat. PLEASE CHANGE uploader_callsign IN [habitat] BLOCK BELOW BEFORE ENABLING THIS
 enable_habitat = False
@@ -102,6 +96,9 @@ synchronous_upload = True
 aprs_user = N0CALL
 aprs_pass = 00000
 
+# APRS-IS server to upload to.
+aprs_server = rotate.aprs2.net
+
 # Object name to be used when uploading to APRS-IS (Max 9 chars)
 # Should be either a callsign with a -11 or -12 suffix (i.e. N0CALL-12),
 # or <id>, which will be replaced with the radiosondes serial number
@@ -115,12 +112,12 @@ aprs_object_id = <id>
 # <temp> - Sonde reported temperature. If no temp data available, this will report -273 degC. Only works for RS41s.
 aprs_custom_comment = Radiosonde Auto-RX <freq>
 
-# Settings for uploading to the Habitat HAB tracking database
-# Note that the habitat upload will use a fixed string format of:
-#`$$<payload_callsign>,<sequence number>,<time>,<lat>,<lon>,<alt>,<speed>,<temp>,<humidity>,<comment>*<CRC16>`
-# Where callsign is set below. Temp and Humidity values are currently fixed to 0, as the RS
-# code doesn't extract the PTU data at this time.
-# You will need to create an appropriate Habitat payload document for this data to appear on the habitat tracker.
+
+# Settings for uploading to the Habitat HAB tracking database ( https://tracker.habhub.org/ )
+#   Note that the habitat upload will use a fixed string format of:
+#  `$$<payload_callsign>,<sequence number>,<time>,<lat>,<lon>,<alt>,<speed>,<temp>,<humidity>,<comment>*<CRC16>`
+#   Where callsign is set below. Temp values are only supported on the RS41 at this time.
+#   If you use a custom payload callsign, you will need to create an appropriate payload document for it to appear on the map
 # 
 [habitat]
 # Payload callsign - if set to <id> will use the serial number of the sonde and create a payload document automatically
@@ -131,20 +128,6 @@ uploader_callsign = SONDE_AUTO_RX
 # Upload listener position to Habitat? (So you show up on the map)
 upload_listener_position = False
 
-# Rotator Settings
-# auto_rx can communicate with an instance of rotctld, on either the local machine or elsewhere on the network.
-# The update rate is tied to the upload_rate setting above, though internet upload does not need to be enabled
-# for the rotator to be updated.
-[rotator]
-enable_rotator = False
-# Hostname / Port of the rotctld instance.
-rotator_hostname = 127.0.0.1
-rotator_port = 4533
-# Rotator Homing.
-# If enabled, turn to this location when scanning for sondes.
-rotator_homing_enabled = False
-rotator_home_azimuth = 0
-rotator_home_elevation = 0
 
 # Settings for pushing data into OziPlotter
 # Oziplotter receives data via a basic CSV format, via UDP.
@@ -157,19 +140,35 @@ ozi_port = 55681
 payload_summary_enabled = False
 payload_summary_port = 55672
 
+
 # Position Filtering Options
-# These are used to discard positions which are clearly bad, such as where the payload has jumped halfway around the world,
-# or has suddenly ended up in orbit.
-# Adjust only if absolutely necessary.
+#   These are used to discard positions which are clearly bad, such as where the payload has jumped halfway around the world,
+#   or has suddenly ended up in orbit.
+#   Adjust only if absolutely necessary.
 [filtering]
 # Discard positions with an altitude greater than 50000 metres. 
 max_altitude = 50000
 # Discard positions more than 1000 km from the observation station location (if set)
 max_radius_km = 1000
 
-# MQTT
-# Post all sonde messages to a MQTT server
+# MQTT (Even more interfacing options!)
+#   Post all sonde messages to a MQTT server
 [mqtt]
 mqtt_enabled = False
 mqtt_hostname = 127.0.0.1
 mqtt_port = 1883
+
+# Rotator Settings
+#   auto_rx can communicate with an instance of rotctld, on either the local machine or elsewhere on the network.
+#   The update rate is tied to the upload_rate setting above, though internet upload does not need to be enabled
+#   for the rotator to be updated.
+[rotator]
+enable_rotator = False
+# Hostname / Port of the rotctld instance.
+rotator_hostname = 127.0.0.1
+rotator_port = 4533
+# Rotator Homing.
+# If enabled, turn to this location when scanning for sondes.
+rotator_homing_enabled = False
+rotator_home_azimuth = 0
+rotator_home_elevation = 0


### PR DESCRIPTION
- APRS Server selection in config file.
- Add options for paths to rtl_fm and rtl_power to the config file. This will allow for further experimentation with the rx_tools utilities (once a few issues have been resolved).
- Stop APRS packets being uploaded if the radiosonde has no GPS lock.
- Some re-structuring of the config file.