### PR TITLE
Prepend RS_ to habitat payload name/callsign

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -748,8 +748,8 @@ def internet_push_thread(station_config):
                 
                 payload_callsign = config['payload_callsign']
                 if config['payload_callsign'] == "<id>":
-                    initPayloadDoc(data['id'], config['payload_description']) # it's fine for us to call this multiple times as initPayloadDoc keeps a cache for serial numbers it's created payloads for.
-                    payload_callsign = data['id']
+                    payload_callsign = 'RS_' + data['id']
+                    initPayloadDoc(payload_callsign, config['payload_description']) # it's fine for us to call this multiple times as initPayloadDoc keeps a cache for serial numbers it's created payloads for.
 
                 # Create comment field.
                 habitat_comment = "%s%s %s %s" % (data['type'], _ozone, data['id'], data['freq'])


### PR DESCRIPTION
Implements #50 

Seemed to work OK for RS_N4810433 this afternoon

Note that function  initPayloadDoc uses the variable name "serial" internally for what is no longer strictly the serial number. Let me know if you'd like the pull request updated with that changed to e.g. payload_callsign
