### PR TITLE
Added regex-based payload ID filtering, and payload validity checks.

### DIFF
--- a/auto_rx/config_reader.py
+++ b/auto_rx/config_reader.py
@@ -63,7 +63,8 @@ def read_auto_rx_config(filename):
 		'blacklist'	: [],
 		'greylist'	: [],
 		'max_altitude'	: 50000,
-		'max_radius_km'	: 1000
+		'max_radius_km'	: 1000,
+		'payload_id_valid' : 5 # TODO: Add this to config file in next bulk update.
 	}
 
 	try:


### PR DESCRIPTION
This PR adds the following:

- Check the payload ID (serial number) against a regex based on Vaisala serial number datasheets. The regex used is: [J-T][0-5][\d][1-7]\d{4}
- Maintain a list of observed payload IDs, and only permit uploading to web services (Habitat, APRS), if a particular ID has been observed more than 5 times. This value is based on observed occurrences of corrupted payload IDs.