### PR TITLE
Remove urllib2/httplib dependencies, other updates.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -291,7 +291,10 @@ def sonde_search(config, attempts = 5):
                 _index = np.argwhere(peak_frequencies==_frequency)
                 peak_frequencies = np.delete(peak_frequencies, _index)
 
-            logging.info("Performing scan on %d frequencies (MHz): %s" % (len(peak_frequencies),str(peak_frequencies/1e6)))
+            if len(peak_frequencies) == 0:
+                logging.info("No peaks found after blacklist frequencies removed.")
+            else:
+                logging.info("Performing scan on %d frequencies (MHz): %s" % (len(peak_frequencies),str(peak_frequencies/1e6)))
 
         else:
             # We have been provided a whitelist - scan through the supplied frequencies.

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -36,7 +36,7 @@ from gps_grabber import *
 from async_file_reader import AsynchronousFileReader
 
 # TODO: Break this out to somewhere else, that is set automatically based on releases...
-AUTO_RX_VERSION = '20180325'
+AUTO_RX_VERSION = '20180415'
 
 # Logging level
 # INFO = Basic status messages

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -887,6 +887,12 @@ if __name__ == "__main__":
     stdout_handler.setFormatter(stdout_format)
     logging.getLogger().addHandler(stdout_handler)
 
+    # Set the requests logger to only display WARNING messages or higher.
+    requests_log = logging.getLogger("requests")
+    requests_log.setLevel(logging.CRITICAL)
+    urllib3_log = logging.getLogger("urllib3")
+    urllib3_log.setLevel(logging.CRITICAL)
+
     # Command line arguments. 
     parser = argparse.ArgumentParser()
     parser.add_argument("-c" ,"--config", default="station.cfg", help="Receive Station Configuration File")

--- a/auto_rx/gps_grabber.py
+++ b/auto_rx/gps_grabber.py
@@ -5,7 +5,7 @@
 # 2017-04 Mark Jessop <vk5qi@rfhead.net>
 #
 import ftplib
-import urllib2
+import requests
 import datetime
 import logging
 import os
@@ -49,12 +49,11 @@ def get_ephemeris(destination="ephemeris.dat"):
 		logging.error("Could not download ephemeris file.")
 		return None
 
-def get_almanac(destination="almanac.txt"):
+def get_almanac(destination="almanac.txt", timeout=20):
 	''' Download the latest GPS almanac file from the US Coast Guard website. '''
 	try:
-		req = urllib2.Request("https://www.navcen.uscg.gov/?pageName=currentAlmanac&format=sem")
-		res = urllib2.urlopen(req)
-		data = res.read()
+		_r = requests.get("https://www.navcen.uscg.gov/?pageName=currentAlmanac&format=sem", timeout=timeout)
+		data = _r.text
 		if "CURRENT.ALM" in data:
 			f = open(destination,'wb')
 			f.write(data)

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -90,8 +90,8 @@ def habitat_upload_payload_telemetry(telemetry, payload_callsign = "RADIOSONDE",
 # from https://raw.githubusercontent.com/rossengeorgiev/hab-tools/master/spot2habitat_chase.py
 #
 callsign_init = False
-url_habitat_uuids = "http://habitat.habhub2.org/_uuids?count=%d"
-url_habitat_db = "http://habitat.habhub2.org/habitat/"
+url_habitat_uuids = "http://habitat.habhub.org/_uuids?count=%d"
+url_habitat_db = "http://habitat.habhub.org/habitat/"
 url_check_callsign = "http://spacenear.us/tracker/datanew.php?mode=6hours&type=positions&format=json&max_positions=10&position_id=0&vehicle=%s"
 uuids = []
 

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -2,11 +2,10 @@
 #
 # Radiosonde Auto RX Tools - Habitat Upload
 #
-# 2017-04 Mark Jessop <vk5qi@rfhead.net>
+# 2018-04 Mark Jessop <vk5qi@rfhead.net>
 #
 import crcmod
-import httplib
-import urllib2
+import requests
 import datetime
 import logging
 import time
@@ -45,7 +44,7 @@ def telemetry_to_sentence(sonde_data, payload_callsign="RADIOSONDE", comment=Non
     output = sentence + "*" + checksum + "\n"
     return output
 
-def habitat_upload_payload_telemetry(telemetry, payload_callsign = "RADIOSONDE", callsign="N0CALL", comment=None):
+def habitat_upload_payload_telemetry(telemetry, payload_callsign = "RADIOSONDE", callsign="N0CALL", comment=None, timeout=10):
 
     sentence = telemetry_to_sentence(telemetry, payload_callsign = payload_callsign, comment=comment)
 
@@ -65,30 +64,72 @@ def habitat_upload_payload_telemetry(telemetry, payload_callsign = "RADIOSONDE",
                 },
             },
     }
-    try:
-        c = httplib.HTTPConnection("habitat.habhub.org",timeout=4)
-        c.request(
-            "PUT",
-            "/habitat/_design/payload_telemetry/_update/add_listener/%s" % sha256(sentence_b64).hexdigest(),
-            json.dumps(data),  # BODY
-            {"Content-Type": "application/json"}  # HEADERS
-            )
 
-        response = c.getresponse()
-        logging.info("Telemetry uploaded to Habitat: %s" % sentence)
-        return
+
+    # The URl to upload to.
+    _url = "http://habitat.habhub.org/habitat/_design/payload_telemetry/_update/add_listener/%s" % sha256(sentence_b64).hexdigest()
+
+    try:
+        # Run the request.
+        _req = requests.put(_url, data=json.dumps(data), timeout=timeout)
+
+        if _req.status_code == 201:
+            logging.info("Uploaded sentence to Habitat successfully: %s" % sentence)
+        elif _req.status_code == 403:
+            logging.info("Sentence uploaded to Habitat, but already present in database.")
+        else:
+            logging.error("Error uploading to Habitat. Status Code: %d" % _req.status_code)
+
     except Exception as e:
-        logging.error("Failed to upload to Habitat: %s" % (str(e)))
-        return
+        logging.error("Error Uploading to Habitat: %s" % str(e))
+
+    return
 
 #
 # Functions for uploading a listener position to Habitat.
 # from https://raw.githubusercontent.com/rossengeorgiev/hab-tools/master/spot2habitat_chase.py
 #
 callsign_init = False
-url_habitat_uuids = "http://habitat.habhub.org/_uuids?count=%d"
-url_habitat_db = "http://habitat.habhub.org/habitat/"
+url_habitat_uuids = "http://habitat.habhub2.org/_uuids?count=%d"
+url_habitat_db = "http://habitat.habhub2.org/habitat/"
+url_check_callsign = "http://spacenear.us/tracker/datanew.php?mode=6hours&type=positions&format=json&max_positions=10&position_id=0&vehicle=%s"
 uuids = []
+
+
+def check_callsign(callsign, timeout=10):
+    ''' 
+    Check if a payload document exists for a given callsign. 
+
+    This is done in a bit of a hack-ish way at the moment. We just check to see if there have
+    been any reported packets for the payload callsign on the tracker.
+    This should really be replaced with the correct call into the habitat tracker.
+    '''
+    global url_check_callsign
+
+    # Perform the request
+    _r = requests.get(url_check_callsign % callsign, timeout=timeout)
+
+    try:
+        # Read the response in as JSON
+        _r_json = _r.json()
+
+        # Read out the list of positions for the requested callsign
+        _positions = _r_json['positions']['position']
+
+        # If there is at least one position returned, we assume there is a valid payload document.
+        if len(_positions) > 0:
+            logging.info("Callsign %s already present in Habitat DB, not creating new payload doc." % callsign)
+            return True
+        else:
+            # Otherwise, we don't, and go create one.
+            return False
+
+    except Exception as e:
+        # Handle errors with JSON parsing.
+        logging.error("Unable to request payload positions from spacenear.us - %s" % str(e))
+        return False
+
+
 
 # Keep an internal cache for which payload docs we've created so we don't spam couchdb with updates
 payload_config_cache = {}
@@ -98,13 +139,24 @@ def ISOStringNow():
     return "%sZ" % datetime.datetime.utcnow().isoformat()
 
 
-def initPayloadDoc(serial, description="Meteorology Radiosonde", frequency=401500000):
+def initPayloadDoc(serial, description="Meteorology Radiosonde", frequency=401500000, timeout=20):
     """Creates a payload in Habitat for the radiosonde before uploading"""
     global url_habitat_db
     global payload_config_cache 
     
+    # First, check if the payload's serial number is already in our local cache.
     if serial in payload_config_cache:
         return payload_config_cache[serial]
+
+    # Next, check to see if the payload has been observed on the online tracker already.
+    _callsign_present = False# check_callsign(serial)
+
+    if _callsign_present:
+        # Add the callsign to the local cache.
+        payload_config_cache[serial] = serial
+        return
+
+    # Otherwise, proceed to creating a new payload document.
 
     payload_data = {
         "type": "payload_configuration",
@@ -184,56 +236,64 @@ def initPayloadDoc(serial, description="Meteorology Radiosonde", frequency=40150
             }
         ]
     }
-    
 
-    data = json.dumps(payload_data)
-    headers = {
-            'Content-Type': 'application/json; charset=utf-8'
-            }
+    # Perform the POST request to the Habitat DB.
+    try:
+        _r = requests.post(url_habitat_db, json=payload_data, timeout=timeout)
 
-    req = urllib2.Request(url_habitat_db, data, headers)
-    response = json.loads(urllib2.urlopen(req, timeout=30).read())
-    if response['ok'] == True:
-        logging.info("Habitat Listener: Created a payload document for %s" % serial)
-        payload_config_cache[serial] = response
-    else:
-        logging.error("Habitat Listener: Failed to create a payload document for %s" % serial)
-        logging.error(response)
-    return response
+        if _r.json()['ok'] is True:
+            logging.info("Habitat Listener: Created a payload document for %s" % serial)
+            payload_config_cache[serial] = _r.json()
+        else:
+            logging.error("Habitat Listener: Failed to create a payload document for %s" % serial)
+
+    except Exception as e:
+        logging.error("Habitat Listener: Failed to create a payload document for %s - %s" % (serial, str(e)))
 
 
-def postListenerData(doc):
+
+def postListenerData(doc, timeout=10):
     global uuids, url_habitat_db
     # do we have at least one uuid, if not go get more
     if len(uuids) < 1:
         fetchUuids()
 
-    # add uuid and uploade time
-    doc['_id'] = uuids.pop()
+    # Attempt to add UUID and time data to document.
+    try:
+        doc['_id'] = uuids.pop()
+    except IndexError:
+        logging.error("Habitat Listener: Unable to post listener data - no UUIDs available.")
+        return False
+
     doc['time_uploaded'] = ISOStringNow()
 
-    data = json.dumps(doc)
-    headers = {
-            'Content-Type': 'application/json; charset=utf-8',
-            'Referer': url_habitat_db,
-            }
+    try:
+        _r = requests.post(url_habitat_db, json=doc, timeout=timeout)
+        return True
+    except Exception as e:
+        logging.error("Habitat Listener: Could not post listener data - %s" % str(e))
+        return False
 
-    req = urllib2.Request(url_habitat_db, data, headers)
-    return urllib2.urlopen(req, timeout=30).read()
 
-def fetchUuids():
+def fetchUuids(timeout=10):
     global uuids, url_habitat_uuids
-    while True:
+
+    _retries = 5
+
+    while _retries > 0:
         try:
-            resp = urllib2.urlopen(url_habitat_uuids % 10, timeout=30).read()
-            data = json.loads(resp)
-        except urllib2.HTTPError, e:
-            logging.error("Habitat Listener: Unable to fetch UUIDs, retrying in 10 seconds.")
+            _r = requests.get(url_habitat_uuids % 10, timeout=timeout)
+            uuids.extend(_r.json()['uuids'])
+            logging.debug("Habitat Listener: Got UUIDs")
+            return
+        except Exception as e:
+            logging.error("Habitat Listener: Unable to fetch UUIDs, retrying in 10 seconds - %s" % str(e))
             time.sleep(10)
+            _retries = _retries - 1
             continue
 
-        uuids.extend(data['uuids'])
-        break;
+    logging.error("Habitat Listener: Gave up trying to get UUIDs.")
+    return
 
 
 def initListenerCallsign(callsign, version=''):
@@ -247,19 +307,25 @@ def initListenerCallsign(callsign, version=''):
                 }
             }
 
-    while True:
-        try:
-            resp = postListenerData(doc)
-            logging.debug("Habitat Listener: Listener callsign Initialized.")
-            break;
-        except urllib2.HTTPError, e:
-            logging.error("Habitat Listener: Unable to initialize callsign. Retrying...")
-            time.sleep(10)
-            continue
+    resp = postListenerData(doc)
+
+    if resp is True:
+        logging.debug("Habitat Listener: Listener Callsign Initialized.")
+        return True
+    else:
+        logging.error("Habitat Listener: Unable to initialize callsign.")
+        return False
+
 
 def uploadListenerPosition(callsign, lat, lon, version=''):
     """ Initializer Listener Callsign, and upload Listener Position """
-    initListenerCallsign(callsign, version=version)
+
+    # Attempt to initialize the listeners callsign
+    resp = initListenerCallsign(callsign, version=version)
+    # If this fails, it means we can't contact the Habitat server,
+    # so there is no point continuing.
+    if resp is False:
+        return
 
     doc = {
         'type': 'listener_telemetry',
@@ -275,12 +341,9 @@ def uploadListenerPosition(callsign, lat, lon, version=''):
     }
 
     # post position to habitat
-    try:
-        postListenerData(doc)
-    except urllib2.HTTPError, e:
-        traceback.print_exc()
+    resp = postListenerData(doc)
+    if resp is True:
+        logging.info("Habitat Listener: Listener information uploaded.")
+    else:
         logging.error("Habitat Listener: Unable to upload listener information.")
-        return
 
-    logging.info("Habitat Listener: Listener information uploaded.")
-    return

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -14,9 +14,6 @@ import json
 from base64 import b64encode
 from hashlib import sha256
 
-# Set the requests logger to only display WARNING messages or higher.
-logging.getLogger("requests").setLevel(logging.WARNING)
-
 #
 # Functions for uploading telemetry to Habitat
 #

--- a/auto_rx/habitat_utils.py
+++ b/auto_rx/habitat_utils.py
@@ -5,14 +5,17 @@
 # 2018-04 Mark Jessop <vk5qi@rfhead.net>
 #
 import crcmod
-import requests
 import datetime
 import logging
+import requests
 import time
 import traceback
 import json
 from base64 import b64encode
 from hashlib import sha256
+
+# Set the requests logger to only display WARNING messages or higher.
+logging.getLogger("requests").setLevel(logging.WARNING)
 
 #
 # Functions for uploading telemetry to Habitat


### PR DESCRIPTION
This PR does the following:

- Replaces all urllib2/httplib calls with calls to requests - brings us a bit closer to Python 3 support.
- Adds checking for the current sonde callsign on the tracker before creating a new payload document. This will hopefully help avoid the creation of multiple documents for the one payload.
- Some better logging around scanning when a blacklist is used.