### PR TITLE
Add support for older/newer vaisala serial numbers.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -342,7 +342,9 @@ def telemetry_filter(telemetry):
     # RS92: https://www.vaisala.com/sites/default/files/documents/Vaisala%20Radiosonde%20RS92%20Serial%20Number.pdf
     # RS41: https://www.vaisala.com/sites/default/files/documents/Vaisala%20Radiosonde%20RS41%20Serial%20Number.pdf
     # This will need to be re-evaluated if we're still using this code in 2021!
-    vaisala_callsign_valid = re.match(r'[J-T][0-5][\d][1-7]\d{4}', _serial)
+    # UPDATE: Had some confirmation that Vaisala will continue to use the alphanumeric numbering up until
+    # ~2025-2030, so have expanded the regex to match (and also support some older RS92s)
+    vaisala_callsign_valid = re.match(r'[E-Z][0-5][\d][1-7]\d{4}', _serial)
 
     # Regex to check DFM06/09 callsigns.
     # TODO: Check if this valid for DFM06s, and find out what's up with the 8-digit DFM09 callsigns.

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -5,7 +5,7 @@
 #   Copyright (C) 2018  Mark Jessop <vk5qi@rfhead.net>
 #   Released under GNU GPL v3 or later
 #
-__version__ = "20180808"
+__version__ = "20180928"
 
 # Global Variables
 


### PR DESCRIPTION
Fixed an issue where older Vaisala RS92s (Pre-~2015 or so) were being detected as invalid serial numbers.
I'm also pre-emptively adding support for RS41s manufactured after 2021. Thinking ahead :-)