### PR TITLE
Use werkzeug by default, suppress any gevent messages.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -400,6 +400,7 @@ def main():
     logging.getLogger('werkzeug').setLevel(logging.ERROR)
     logging.getLogger('socketio').setLevel(logging.ERROR)
     logging.getLogger('engineio').setLevel(logging.ERROR)
+    logging.getLogger('geventwebsocket').setLevel(logging.ERROR)
 
 
     # Attempt to read in config file

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -5,7 +5,7 @@
 #   Copyright (C) 2018  Mark Jessop <vk5qi@rfhead.net>
 #   Released under GNU GPL v3 or later
 #
-__version__ = "20181215"
+__version__ = "20181227"
 
 # Global Variables
 

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -37,7 +37,7 @@ flask_app_thread = None
 flask_shutdown_key = "temp"
 
 # SocketIO instance
-socketio = SocketIO(app)
+socketio = SocketIO(app, async_mode='threading')
 
 # Global store of telemetry data, which we will add data to and manage.
 # Under each key (which will be the sonde ID), we will have a dictionary containing:


### PR DESCRIPTION
Small pull request to temporarily fix https://github.com/projecthorus/radiosonde_auto_rx/issues/98

Really needs testing by someone that has gevent installed to ensure the forcing of werkzeug works.