### PR TITLE
Fixed error if -h

### DIFF
--- a/m10/M10Decoder.cpp
+++ b/m10/M10Decoder.cpp
@@ -15,13 +15,16 @@ M10Decoder::M10Decoder() {
     m10GTop = new M10GTopParser();
     m10Ptu = new M10PtuParser();
     m10Parser = m10GTop;
+    
+    frameSamples = NULL;
+    audioFile = NULL;
 }
 
 M10Decoder::~M10Decoder() {
     delete m10GTop;
     delete m10Ptu;
 
-    if (audioFile)
+    if (frameSamples)
         delete frameSamples;
 
     if (audioFile)


### PR DESCRIPTION
Fixed a typo and some necessary allocation to avoid errors on deleting M10Decoder object before everything is allocated

Tested & working on windows and linux using the build.sh script.