### PR TITLE
Switch to dft_detect for scanning.

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -5,7 +5,7 @@
 #   Copyright (C) 2018  Mark Jessop <vk5qi@rfhead.net>
 #   Released under GNU GPL v3 or later
 #
-__version__ = "20190211-beta"
+__version__ = "20190227-beta"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -246,12 +246,13 @@ class SondeDecoder(object):
             # DFM06/DFM09 Sondes.
             # As of 2019-02-10, dfm09ecc auto-detects if the signal is inverted,
             # so we don't need to specify an invert flag.
+            # 2019-02-27: Added the --dist flag, which should reduce bad positions a bit.
 
             # Note: Have removed a 'highpass 20' filter from the sox line, will need to re-evaluate if adding that is useful in the future.
             decode_cmd = "%s %s-p %d -d %s %s-M fm -F9 -s 15k -f %d 2>/dev/null |" % (self.sdr_fm, bias_option, int(self.ppm), str(self.device_idx), gain_param, self.sonde_freq)
             decode_cmd += "sox -t raw -r 15k -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 lowpass 2000 2>/dev/null |"
             # DFM decoder
-            decode_cmd += "./dfm09ecc -vv --ecc --json --auto 2>/dev/null"
+            decode_cmd += "./dfm09ecc -vv --ecc --json --dist --auto 2>/dev/null"
 			
         elif self.sonde_type == "M10":
             # M10 Sondes

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -191,54 +191,80 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
     else:
         gain_param = ''
 
+    # Sample Source (rtl_fm)
     rx_test_command = "timeout %ds %s %s-p %d -d %s %s-M fm -F9 -s 22k -f %d 2>/dev/null |" % (dwell_time, sdr_fm, bias_option, int(ppm), str(device_idx), gain_param, frequency) 
+    # Sample filtering
     rx_test_command += "sox -t raw -r 22k -e s -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null |"
-    rx_test_command += os.path.join(rs_path,"rs_detect") + " -z -t 8 2>/dev/null >/dev/null"
+    # Sample decoding / detection
+    rx_test_command += os.path.join(rs_path,"dft_detect") + " 2>/dev/null"
+
+    #print(rx_test_command)
 
     logging.debug("Scanner #%s - Attempting sonde detection on %.3f MHz" % (str(device_idx), frequency/1e6))
 
     try:
         FNULL = open(os.devnull, 'w')
-        ret_code = subprocess.call(rx_test_command, shell=True, stderr=FNULL)
+        ret_output = subprocess.check_output(rx_test_command, shell=True, stderr=FNULL)
         FNULL.close()
+    except subprocess.CalledProcessError as e:
+        # dft_detect returns a code of 1 if no sonde is detected.
+        # logging.debug("Scanner - dfm_detect return code: %s" % e.returncode)
+        if e.returncode >= 2:
+            ret_output = e.output
+        else:
+            return None
     except Exception as e:
         # Something broke when running the detection function.
-        logging.error("Scanner #%s - Error when running rs_detect - %s" % (str(device_idx), str(e)))
+        logging.error("Scanner #%s - Error when running dft_detect - %s" % (str(device_idx), str(e)))
         return None
 
-    # Shift down by a byte... for some reason.
-    # NOTE: For some reason, we don't need to do this when using subprocess.call vs when using os.system.
-    # Should probably figure out why this is the case at some point.
-    #ret_code = ret_code >> 8
+    # Check for no output from dft_detect.
+    if ret_output is None or ret_output == "":
+        #logging.error("Scanner - dft_detect returned no output?")
+        return None
 
-    # Default is non-inverted FM.
-    inv = ""
+    # dft_detect return codes:
+    # 2 = DFM
+    # 3 = RS41
+    # 4 = RS92
+    # 5 = M10
+    # 6 = IMET (AB)
+    # 7 = IMET (RS)
+    # 8 = LMS6
+    # 9 = C34/C50
 
-    # Check if the inverted bit is set
-    if (ret_code & 0x80) > 0: 
-        # If the inverted bit is set, we have to do some munging of the return code to get the sonde type.
-        ret_code = abs(-1 * (0x100 - ret_code))
+    # Split the line into sonde type and correlation score.
+    _fields = ret_output.split(':')
 
-        inv = "-"
+    if len(_fields) <2:
+        logging.error("Scanner - malformed output from dft_detect: %s" % ret_output.strip())
+        return None
 
-    else:
-        ret_code = abs(ret_code)
+    _type = _fields[0]
+    _score = float(_fields[1].strip())
 
-    if ret_code == 3:
-        logging.debug("Scanner #%s - Detected a RS41!" % str(device_idx))
-        return inv+"RS41"
-    elif ret_code == 4:
-        logging.debug("Scanner #%s - Detected a RS92!" % str(device_idx))
-        return inv+"RS92"
-    elif ret_code == 2:
-        logging.debug("Scanner #%s - Detected a DFM Sonde!" % str(device_idx))
-        return inv+"DFM"
-    elif ret_code == 5:
-        logging.debug("Scanner #%s - Detected a M10 Sonde!" % str(device_idx))
-        return inv+"M10"
-    elif ret_code == 6:
-        logging.debug("Scanner #%s - Detected a iMet Sonde! (Unsupported)" % str(device_idx))
-        return inv+"iMet"
+
+    if 'RS41' in _type:
+        logging.debug("Scanner #%s - Detected a RS41! (Score: %.2f)" % (str(device_idx), _score))
+        return "RS41"
+    elif 'RS92' in _type:
+        logging.debug("Scanner #%s - Detected a RS92! (Score: %.2f)" % (str(device_idx), _score))
+        return "RS92"
+    elif 'DFM' in _type:
+        logging.debug("Scanner #%s - Detected a DFM Sonde! (Score: %.2f)" % (str(device_idx), _score))
+        return "DFM"
+    elif 'M10' in _type:
+        logging.debug("Scanner #%s - Detected a M10 Sonde! (Score: %.2f)" % (str(device_idx), _score))
+        return "M10"
+    elif 'IMET' in _type:
+        logging.debug("Scanner #%s - Detected a iMet Sonde! (Unsupported, type %s) (Score: %.2f)" % (str(device_idx), _type, _score))
+        return "iMet"
+    elif 'LMS6' in _type:
+        logging.debug("Scanner #%s - Detected a LMS6 Sonde! (Unsupported) (Score: %.2f)" % (str(device_idx), _score))
+        return 'LMS6'
+    elif 'C34' in _type:
+        logging.debug("Scanner #%s - Detected a Meteolabor C34/C50 Sonde! (Unsupported) (Score: %.2f)" % (str(device_idx), _score))
+        return 'C34C50'
     else:
         return None
 

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 # List of binaries we check for on startup
-REQUIRED_RS_UTILS = ['rs_detect', 'rs41ecc', 'rs92ecc', 'dfm09ecc', 'm10']
+REQUIRED_RS_UTILS = ['dft_detect', 'rs41ecc', 'rs92ecc', 'dfm09ecc', 'm10']
 
 def check_rs_utils():
     """ Check the required RS decoder binaries exist

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -7,13 +7,14 @@
 echo "Building rs_detect"
 cd ../scan/
 gcc rs_detect.c -lm -o rs_detect
+gcc dft_detect.c -lm -o dft_detect
 
 echo "Building RS92/RS41/DFM Demodulators"
 cd ../demod/
 gcc -c demod.c
 gcc -c demod_dft.c
 gcc rs92dm_dft.c demod_dft.o -lm -o rs92ecc -I../ecc/ -I../rs92
-gcc rs41dm_dft.c demod_dft.o -lm -o rs41ecc -I../ecc/ -I../rs41
+gcc rs41dm_dft.c demod_dft.o -lm -o rs41ecc -I../ecc/ -I../rs41 -w
 gcc dfm09dm_dft.c demod_dft.o -lm -o dfm09ecc -I../ecc/ -I../dfm
 # Build M10 decoder
 echo "Building M10 Demodulator."
@@ -25,6 +26,7 @@ g++ M10.cpp M10Decoder.cpp M10GeneralParser.cpp M10GtopParser.cpp M10TrimblePars
 echo "Copying files into auto_rx directory."
 cd ../auto_rx/
 cp ../scan/rs_detect .
+cp ../scan/dft_detect .
 cp ../demod/rs92ecc .
 cp ../demod/rs41ecc .
 cp ../demod/dfm09ecc .

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -6,7 +6,6 @@
 # Build rs_detect.
 echo "Building rs_detect"
 cd ../scan/
-gcc rs_detect.c -lm -o rs_detect
 gcc dft_detect.c -lm -o dft_detect
 
 echo "Building RS92/RS41/DFM Demodulators"

--- a/auto_rx/test/README.md
+++ b/auto_rx/test/README.md
@@ -1,0 +1,117 @@
+# Radiosonde Demodulator Testing Scripts
+
+For these scripts to work, we need:
+ * The following directories created: samples, generated
+ * The various demodulator binaries (rs41ecc, rs_detect, etc... ) located in ../ Currently using:
+   * dfm09ecc, m10 (from radiosonde_auto_rx), rs41ecc, rs92ecc, rs_detect, dft_detect
+   * The above can just be built using the auto_rx build.sh script.
+ * CSDR installed and available on $PATH: https://github.com/simonyiszk/csdr
+ * The base high-snr samples located in ./samples/. These can be downloaded from http://rfhead.net/sondes/sonde_samples.tar.gz
+ * Python (2, will probably work in 3), with numpy available.
+
+## generate_lowsnr.py
+This script generates a set of low-SNR samples based on the base high-SNR samples in ./samples/
+Calibrated-level noise is added to the sample to produce a file with a user-defined Eb/No ('SNR per-bit').
+If everything works 'perfectly', we should expect all the different modems to have similar PER vs Eb/No performance.
+However, real-world factors such as packet length, transmitter deviation, filter widths, etc will mess this up.
+I wouldn't try and make too many comparions of the performance between different sonde demodulators. Better to strike
+a baseline of current performance, and then try and improve on it.
+
+The level of noise to add is determined based on the variance of the sample. Some checking of Eb/No of generated
+samples has been performed with David Rowe's fsk demod, though only for the RS41 samples so far.
+
+Modify the EBNO_RANGE variable to change the range of Eb/No values to generate. FSK demods generally fall over between about 10 and 16 dB.
+Uncomment the various elements in the SAMPLES array to choose what sample to process.
+
+Then, run with:
+```
+$ cd scripts
+$ python generate_lowsnr.py
+```
+
+
+Notes:
+ * I suspect the variance measurement for the m10 sample is off. Its performing suspiciously better than the other sondes.
+
+
+## test_demod.py
+This script run the generated samples above through different demodulation chains. 
+
+Check the processing_type dict in the script for the differnet demodulation options.
+
+Example:
+```
+# Demodulate all RS41 samples.
+$ python test_demod.py -m rs41_csdr_fm_decode -f "../generated/rs41*.bin"
+
+# Run dft_detect across all samples.
+# python test_demod.py -m csdr_fm_dftdetect -f "../generated/*.bin"
+```
+
+The output is a csv of: filename, result
+
+Depending on the mode, the result could be a packet count, or it could be a success/no success (in the case of the detection utilities).
+
+
+# Sample Capture Information
+- All captures have radiosonde signal at DC, or as close to DC as practicable.
+
+- Captured using: rtl_sdr -f 402500400 -s 960k -g 49.6 -n 115200000 rs41_960k.bin
+- Converted to 96k float IQ using: cat rs41_960k.bin | csdr convert_u8_f | csdr fir_decimate_cc 10 0.005 HAMMING > rs41_96k_float.bin
+
+
+rs41_96k_float.bin - Vaisala RS41, Serial Number N3920808, 120 packets
+rs92_96k_float.bin - Vaisala RS92, Serial Number M2513116, 120 packets
+dfm09_96k_float.bin - Graw DFM09, Serial Number 637797, 96 Packets
+m10_96k_float.bin - Meteomodem M10, 120 packets
+imet4_96k_float.bin - iMet-4, Serial Number 15236, 119 packets
+
+
+# Older Notes
+
+## Reading data into Python
+```
+import numpy as np
+data = np.fromfile('rs41_96k_float.bin', dtype='c8')
+```
+
+
+## Demodulation Examples
+To run these examples, you will need csdr available on the path, and will need the various radiosonde demodulators as built by auto_rx.
+Run the build.sh script in radiosonde_auto_rx/auto_rx to build these, then copy them to your working directory.
+
+NOTE: These are not optimised. Have a look in the test_demod.py script for the 'optimal' demodulation commands.
+
+### RS41
+
+#### Using csdr as a FM demodulator:
+$ cat samples/rs41_96k_float.bin | csdr fir_decimate_cc 2 0.005 HAMMING | csdr bandpass_fir_fft_cc -0.18 0.18 0.05 | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - | ../rs41ecc --ecc --ptu --crc
+
+
+#### Using nanorx as a FM demodulator:
+NOTE - Nanorx seems to invert the FM output, hence the -i option on rs41ecc
+NOTE - As of v0.85, nanorx's FM demodulators are likely corrupting the RS41 signal
+
+$ cat rs41_96k_float.bin | csdr convert_f_s16 | ./nanorx -i stdin -r 96k -m FM -t 10 -o - | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - | ../rs41ecc --ecc --ptu --crc -i
+
+
+### RS92
+
+#### Using csdr as a FM demodulator:
+$ cat rs92_96k_float.bin | csdr fir_decimate_cc 2 0.005 HAMMING | csdr bandpass_fir_fft_cc -0.18 0.18 0.05 | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - | ../rs92ecc
+
+
+### DFM09
+
+#### Using csdr as a FM demodulator:
+$ cat dfm09_96k_float.bin | csdr fir_decimate_cc 2 0.005 HAMMING | csdr bandpass_fir_fft_cc -0.18 0.18 0.05 | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - | ../dfm09ecc --auto
+
+
+### iMet 4
+Note that the imet decoder isn't used in auto_rx yet. Build from the imet directory using:
+$ gcc imet1rs_dft.c -lm -o imet1rs_dft
+
+#### Using csdr as a FM demodulator:
+$ cat imet4_96k_float.bin | csdr fir_decimate_cc 2 0.005 HAMMING | csdr bandpass_fir_fft_cc -0.18 0.18 0.05 | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - | ../imet1rs_dft
+
+

--- a/auto_rx/test/generate_lowsnr.py
+++ b/auto_rx/test/generate_lowsnr.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+#
+#   Generate Noisy Sonde Samples, with a calibrated Eb/No
+#
+#   Run from ./scripts/ with
+#   $ python generate_lowsnr.py
+#
+#   The generated files will end up in the 'generated' directory.
+#
+#   Mark Jessop 2019-02
+#
+import numpy as np
+import os
+
+
+# Where to find the samples files.
+# These are all expected to be 96khz float (dtype='c8') files.
+SAMPLE_DIR = "./samples"
+
+# Directory to output generated files
+GENERATED_DIR = "./generated"
+
+# Range of Eb/N0 SNRs to produce.
+# 10-20 dB seems to be the range where the demodulators fall over.
+EBNO_RANGE = np.arange(10,20,0.5)
+
+
+# List of samples
+# [filename, baud_date, threshold, sample_rate]
+# filename = string, without path
+# baud_rate = integer
+# threshold = threshold for calculating variance. Deterimined by taking 20*np.log10(np.abs(data)) and looking for packets.
+# sample_rate = input file sample rate.
+
+SAMPLES = [
+    ['rs41_96k_float.bin', 4800, -25.0, 96000], 
+    ['rs92_96k_float.bin', 2400, -100, 96000], # No threshold set, as signal is continuous.
+    ['dfm09_96k_float.bin', 2500, -100, 96000], # Weird baud rate. No threshold set, as signal is continuous.
+    ['m10_96k_float.bin', 9616, -18.0, 96000]  # Really weird baud rate. WARNING - Samples output by this are a bit questionable at the moment.
+]
+
+
+
+def load_sample(filename):
+    _filename = os.path.join(SAMPLE_DIR, filename)
+    return np.fromfile(_filename, dtype='c8')
+
+
+def save_sample(data, filename):
+    _filename = os.path.join(GENERATED_DIR, filename)
+    # We have to make sure to convert to complex64..
+    data.astype(dtype='c8').tofile(_filename)
+
+    # TODO: Allow saving as complex s16 - see view solution here: https://stackoverflow.com/questions/47086134/how-to-convert-a-numpy-complex-array-to-a-two-element-float-array
+
+
+
+def calculate_variance(data, threshold=-100.0):
+    # Calculate the variance of a set of radiosonde samples.
+    # Optionally use a threshold to limit the sample the variance 
+    # is calculated over to ones that actually have sonde packets in them.
+
+    _data_log = 20*np.log10(np.abs(data))
+
+    return np.var(data[_data_log>threshold])
+
+
+def add_noise(data, variance, baud_rate, ebno, fs=96000,  bitspersymbol=1.0):
+    # Add calibrated noise to a sample.
+
+    # Calculate Eb/No in linear units.
+    _ebno = 10.0**(ebno/10.0)
+
+    # Calculate the noise variance we need to add
+    _noise_variance = variance*fs/(baud_rate*_ebno*bitspersymbol)
+
+    # Generate complex random samples
+    _rand_i = np.sqrt(_noise_variance/2.0)*np.random.randn(len(data))
+    _rand_q = np.sqrt(_noise_variance/2.0)*np.random.randn(len(data))
+
+    return (data + (1j*_rand_i + _rand_q))
+
+
+
+
+if __name__ == '__main__':
+
+    for _sample in SAMPLES:
+        # Extract the stuff we need from the entry.
+        _source = _sample[0]
+        _baud_rate = _sample[1]
+        _threshold = _sample[2]
+        _fs = _sample[3]
+
+        print("Generating samples for: %s" % _source)
+
+        # Read in source file.
+        _data = load_sample(_source)
+
+        # Calculate variance
+        _var = calculate_variance(_data, _threshold)
+        print("Calculated Variance: %.5f" % _var)
+
+        # Now loop through the ebno's and generate the output.
+        for ebno in EBNO_RANGE:
+            _data_noise = add_noise(_data, variance=_var, baud_rate=_baud_rate, ebno=ebno, fs=_fs)
+
+            _out_file = _source.split('.bin')[0] + "_%.1fdB"%ebno + ".bin"
+
+            save_sample(_data_noise, _out_file)
+            print("Saved file: %s" % _out_file)
+
+
+
+
+
+

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python
+#
+#   Run a set of files through a processing and decode chain, and handle the output.
+#
+#   Mark Jessop 2019-02
+#
+#   Refer to the README.md in this directory for instructions on use.
+#
+import glob
+import argparse
+import os
+import sys
+import subprocess
+
+
+# Dictionary of available processing types.
+
+processing_type = {
+    # RS41 Decoding
+    'rs41_csdr_fm_decode': {
+        # Decode a RS41 using a CSDR processing chain to do FM demodulation
+        # Decimate to 48 khz, filter, then demodulate.
+        #'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.18 0.18 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 24 kHz channel, demod, then interpolate back up to 48 kHz.
+        #'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 12 khz channel, demod, then interpolate back up to 48 kHz. - WORKS BEST
+        'demod' : "| csdr fir_decimate_cc 8 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 4 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../rs41ecc --ecc --ptu --crc 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep N3920808 | wc -l"
+    },
+    # RS92 Decoding
+    'rs92_csdr_fm_decode': {
+        # Decode a RS92 using a CSDR processing chain to do FM demodulation
+        # Decimate to 48 khz, filter to +/-4.8kHz, then demodulate. - WORKS BEST
+        'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.10 0.10 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 24 kHz channel, demod, then interpolate back up to 48 kHz.
+        #'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 12 khz channel, demod, then interpolate back up to 48 kHz.
+        #'demod' : "| csdr fir_decimate_cc 8 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 4 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../rs92ecc -vx -v --crc --ecc --vel 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep M2513116 | wc -l"
+    },
+    # DFM Decoding
+    'dfm_csdr_fm_decode': {
+        # Decode a DFM using a CSDR processing chain to do FM demodulation
+        # Decimate to 48 khz, filter to +/-6kHz, then demodulate.
+        #'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.12 0.12 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 24 kHz channel, demod, then interpolate back up to 48 kHz.
+        #'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 12 khz channel, demod, then interpolate back up to 48 kHz. - WORKS BEST
+        'demod' : "| csdr fir_decimate_cc 8 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 4 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../dfm09ecc -vv --ecc --json --dist --auto 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep frame |  wc -l"
+    },
+    #   M10 Radiosonde decoding.
+    'm10_csdr_fm_decode': {
+        # M10 Decoding
+        # Use a CSDR processing chain to do FM demodulation
+        # Decimate to 48 khz, filter, then demodulate. - WORKS BEST
+        'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.23 0.23 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decimate to a 24 kHz channel, demod, then interpolate back up to 48 kHz.
+        #'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../m10 -b -b2 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : "| wc -l"
+    },
+    #   rs_detect - Sonde Detection.
+    #   Current approach in auto_rx uses rtl_fm with a 22 khz sample rate (channel bw?) setting,
+    #   then resamples up to 48 khz sampes to feed into rs_detect.
+    #
+    'csdr_fm_rsdetect': {
+        # Use a CSDR processing chain to do FM demodulation
+        # Using a ~22kHz wide filter, and 20 Hz high-pass
+        # Decimate to 48 khz, filter to ~22 kHz BW, then demod.
+        # rs_detect seem to like this better than the decimation approach.
+        #'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.23 0.23 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null| ",
+        # Decimate to 24 khz before passing into the FM demod. This is roughly equivalent to rtl_fm -r 22k
+        'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../rs_detect -z -t 8 2> /dev/null",
+        # Grep out the line containing the detected sonde type.
+        "post_process" : " | grep found"
+    },
+    #   dft_detect - Sonde detection using DFT correlation
+    #   
+    'csdr_fm_dftdetect': {
+        # Use a CSDR processing chain to do FM demodulation
+        # Filter to 22 khz channel bandwidth, then demodulate.
+        #'demod' : "| csdr fir_decimate_cc 2 0.005 HAMMING 2>/dev/null | csdr bandpass_fir_fft_cc -0.23 0.23 0.05 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - 2>/dev/null| ",
+        # Decimate to a 24 kHz bandwidth, demodulator, then interpolate back up to 48 kHz.
+        'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null| ",
+        # Decode using rs41ecc
+        'decode': "../dft_detect 2>/dev/null",
+        # Grep out the line containing the detected sonde type.
+        "post_process" : " | grep \:"
+    },
+    # RS41 Decoding
+    'rs41_fsk_demod': {
+        # Shift up to ~24 khz, and then pass into fsk_demod.
+        'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../bin/fsk_demod --cs16 -b 1 -u 45000 2 96000 4800 - - 2>/dev/null | python ../bin/bit_to_samples.py 48000 4800 | sox -t raw -r 48k -e unsigned-integer -b 8 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+
+        # Decode using rs41ecc
+        'decode': "../rs41ecc --ecc --ptu --crc 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep N3920808 | wc -l"
+    },
+    # RS92 Decoding
+    'rs92_fsk_demod': {
+        # Not currently working - need to resolve segfault in dfk_demod when using 96 kHz Fs ans 2400 Rb
+        # Shift up to ~24 khz, and then pass into fsk_demod.
+        'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../bin/fsk_demod --cs16 -b 1 -u 45000 2 96000 2400 - - 2>/dev/null | python ../bin/bit_to_samples.py 48000 2400 | sox -t raw -r 48k -e unsigned-integer -b 8 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+
+        # Decode using rs41ecc
+        'decode': ".../rs92ecc -vx -v --crc --ecc --vel 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep M2513116 | wc -l"
+    },
+    'm10_fsk_demod': {
+        # Not currently working due to weird baud rate (9614). Doesnt work even with fractional resampling (slow down signal to make it appear to be 9600 baud).
+        # Shift up to ~24 khz, and then pass into fsk_demod.
+        'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../bin/tsrc - - 0.99854 -c | ../bin/fsk_demod --cs16 -b 1 -u 45000 2 96000 9600 - - 2>/dev/null | python ../bin/bit_to_samples.py 48000 9600 | sox -t raw -r 48k -e unsigned-integer -b 8 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null| ",
+        'decode': "../m10 -b -b2 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : "| wc -l"
+    },
+}
+
+
+
+def run_analysis(mode, file_list, shift=0.0):
+
+    _mode = processing_type[mode]
+
+    _first = True
+
+    # Calculate the frequency offset to apply, if defined.
+    _shiftcmd = "| csdr shift_addition_cc %.5f 2>/dev/null" % (shift/96000.0)
+
+    # Iterate over the files in the supplied list.
+    for _file in file_list:
+
+        # Generate the command to run.
+        _cmd = "cat %s "%_file 
+
+        # Add in an optional frequency error if supplied.
+        if shift != 0.0:
+            _cmd += _shiftcmd
+
+        # Add on the rest of the demodulation and decoding commands.
+        _cmd += _mode['demod'] + _mode['decode'] + _mode['post_process']
+
+
+        if _first:
+            print("Command: %s" % _cmd)
+            _first = False
+
+        # Run the command.
+        try:
+            _output = subprocess.check_output(_cmd, shell=True, stderr=None)
+        except:
+            _output = "error"
+
+        print("%s, %s" % (os.path.basename(_file), _output.strip()))
+
+
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--mode", type=str, default="rs41_csdr_fm_decode", help="Operation mode.")
+    parser.add_argument("-f", "--files", type=str, default="./generated/*.bin", help="Glob-path to files to run over.")
+    parser.add_argument("--shift", type=float, default=0.0, help="Shift the signal-under test by x Hz. Default is 0.")
+    args = parser.parse_args()
+
+    # Check the mode is valid.
+    if args.mode not in processing_type:
+        print("Error - invalid operating mode.")
+        print("Valid Modes: %s" % str(processing_type.keys()))
+        sys.exit(1)
+
+
+    # Get the list of files.
+    _file_list = glob.glob(args.files)
+    if len(_file_list) == 0:
+        print("No files found matching supplied path.")
+        sys.exit(1)
+
+    # Sort the list of files.
+    _file_list.sort()
+
+    run_analysis(args.mode, _file_list, shift=args.shift)

--- a/demod/demod_dft.h
+++ b/demod/demod_dft.h
@@ -2,6 +2,7 @@
 float read_wav_header(FILE*, float, int);
 int f32buf_sample(FILE*, int, int);
 int read_sbit(FILE*, int, int*, int, int, int, int);
+int read_spkbit(FILE*, int, int*, int, int, int, int, int);
 int read_softbit(FILE *fp, int symlen, int *bit, float *sb, float level, int inv, int ofs, int reset, int cm);
 float header_level(char hdr[], int hLen, unsigned int pos, int inv);
 

--- a/demod/demod_iq.c
+++ b/demod/demod_iq.c
@@ -12,83 +12,24 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <math.h>
-
-
-typedef unsigned char  ui8_t;
-typedef unsigned short ui16_t;
-typedef unsigned int   ui32_t;
-typedef short i16_t;
-typedef int   i32_t;
 
 #include "demod_iq.h"
 
-
-static int sample_rate = 0, bits_sample = 0, channels = 0;
-static float samples_per_bit = 0;
-
-static unsigned int sample_in, sample_out, delay;
-static int buffered = 0;
-
-static int N, M;
-
-static float *match = NULL,
-             *bufs  = NULL;
-
-static char *rawbits = NULL;
-
-static int Nvar = 0; // < M
-static double xsum=0, qsum=0;
-static float *xs = NULL,
-             *qs = NULL;
-
-
-static float dc_ofs = 0.0;
-static float dc = 0.0;
-
-static int option_iq = 0;
-
 /* ------------------------------------------------------------------------------------ */
 
-#include <complex.h>
 
-static int LOG2N, N_DFT;
-static int M_DFT;
-
-static float complex  *ew;
-
-static float complex  *Fm, *X, *Z, *cx;
-static float *xn;
-
-static float complex  *Hann;
-
-static int N_IQBUF;
-static float complex *raw_iqbuf = NULL;
-static float complex *rot_iqbuf = NULL;
-
-static double df = 0.0;
-static int len_sq = 0;
-
-static unsigned int sample_posframe = 0;
-static unsigned int sample_posnoise = 0;
-
-static double V_noise = 0.0;
-static double V_signal = 0.0;
-static double SNRdB = 0.0;
-
-
-static void cdft(float complex *Z) {
+static void raw_dft(dft_t *dft, float complex *Z) {
     int s, l, l2, i, j, k;
     float complex  w1, w2, T;
 
     j = 1;
-    for (i = 1; i < N_DFT; i++) {
+    for (i = 1; i < dft->N; i++) {
         if (i < j) {
             T = Z[j-1];
             Z[j-1] = Z[i-1];
             Z[i-1] = T;
         }
-        k = N_DFT/2;
+        k = dft->N/2;
         while (k < j) {
             j = j - k;
             k = k/2;
@@ -96,13 +37,13 @@ static void cdft(float complex *Z) {
         j = j + k;
     }
 
-    for (s = 0; s < LOG2N; s++) {
+    for (s = 0; s < dft->LOG2N; s++) {
         l2 = 1 << s;
         l  = l2 << 1;
         w1 = (float complex)1.0;
-        w2 = ew[s]; // cexp(-I*M_PI/(float)l2)
+        w2 = dft->ew[s]; // cexp(-I*M_PI/(float)l2)
         for (j = 1; j <= l2; j++) {
-            for (i = j; i <= N_DFT; i += l) {
+            for (i = j; i <= dft->N; i += l) {
                 k = i + l2;
                 T = Z[k-1] * w1;
                 Z[k-1] = Z[i-1] - T;
@@ -113,32 +54,48 @@ static void cdft(float complex *Z) {
     }
 }
 
-static void rdft(float *x, float complex *Z) {
+static void cdft(dft_t *dft, float complex *z, float complex *Z) {
     int i;
-    for (i = 0; i < N_DFT; i++)  Z[i] = (float complex)x[i];
-    cdft(Z);
+    for (i = 0; i < dft->N; i++)  Z[i] = z[i];
+    raw_dft(dft, Z);
 }
 
-static void Nidft(float complex *Z, float complex *z) {
+static void rdft(dft_t *dft, float *x, float complex *Z) {
     int i;
-    for (i = 0; i < N_DFT; i++)  z[i] = conj(Z[i]);
-    cdft(z);
+    for (i = 0; i < dft->N; i++)  Z[i] = (float complex)x[i];
+    raw_dft(dft, Z);
+}
+
+static void Nidft(dft_t *dft, float complex *Z, float complex *z) {
+    int i;
+    for (i = 0; i < dft->N; i++)  z[i] = conj(Z[i]);
+    raw_dft(dft, z);
     // idft():
-    // for (i = 0; i < N_DFT; i++)  z[i] = conj(z[i])/(float)N_DFT; // hier: z reell
+    // for (i = 0; i < dft->N; i++)  z[i] = conj(z[i])/(float)dft->N; // hier: z reell
 }
 
-static float bin2freq(int k) {
-    float fq = sample_rate * k / N_DFT;
-    if (fq > sample_rate/2.0) fq -= sample_rate;
+static float bin2freq0(dft_t *dft, int k) {
+    float fq = dft->sr * k / /*(float)*/dft->N;
+    if (fq >= dft->sr/2.0) fq -= dft->sr;
+    return fq;
+}
+static float bin2freq(dft_t *dft, int k) {
+    float fq = k / (float)dft->N;
+    if ( fq >= 0.5) fq -= 1.0;
+    return fq*dft->sr;
+}
+static float bin2fq(dft_t *dft, int k) {
+    float fq = k / (float)dft->N;
+    if ( fq >= 0.5) fq -= 1.0;
     return fq;
 }
 
-static int max_bin(float complex *Z) {
+static int max_bin(dft_t *dft, float complex *Z) {
     int k, kmax;
     double max;
 
     max = 0; kmax = 0;
-    for (k = 0; k < N_DFT; k++) {
+    for (k = 0; k < dft->N; k++) {
         if (cabs(Z[k]) > max) {
             max = cabs(Z[k]);
             kmax = k;
@@ -148,68 +105,100 @@ static int max_bin(float complex *Z) {
     return kmax;
 }
 
+static int dft_window(dft_t *dft, int w) {
+    int n;
+
+    if (w < 0 || w > 3) return -1;
+
+    for (n = 0; n < dft->N2; n++) {
+        switch (w)
+        {
+            case 0: // (boxcar)
+                    dft->win[n] = 1.0;
+                    break;
+            case 1: // Hann
+                    dft->win[n] = 0.5 * ( 1.0 - cos(2*M_PI*n/(float)(dft->N2-1)) );
+                    break ;
+            case 2: // Hamming
+                    dft->win[n] = 25/46.0 + (1.0 - 25/46.0)*cos(2*M_PI*n / (float)(dft->N2-1));
+                    break ;
+            case 3: // Blackmann
+                    dft->win[n] =  7938/18608.0
+                                 - 9240/18608.0*cos(2*M_PI*n / (float)(dft->N2-1))
+                                 + 1430/18608.0*cos(4*M_PI*n / (float)(dft->N2-1));
+                    break ;
+        }
+    }
+    while (n < dft->N) dft->win[n++] = 0.0;
+
+    return 0;
+}
+
+
 /* ------------------------------------------------------------------------------------ */
 
-int getCorrDFT(int abs, int K, unsigned int pos, float *maxv, unsigned int *maxvpos) {
+int getCorrDFT(dsp_t *dsp, int abs, ui32_t pos, float *maxv, ui32_t *maxvpos) {
     int i;
     int mp = -1;
     float mx = 0.0;
     float xnorm = 1;
-    unsigned int mpos = 0;
-
-    dc = 0.0;
-
-    if (N + K > N_DFT/2 - 2) return -1;
-    if (sample_in < delay+N+K) return -2;
-
-    if (pos == 0) pos = sample_out;
+    ui32_t mpos = 0;
 
 
-    for (i = 0; i < N+K; i++) xn[i] = bufs[(pos+M -(N+K-1) + i) % M];
-    while (i < N_DFT) xn[i++] = 0.0;
+    dsp->dc = 0.0;
 
-    rdft(xn, X);
+    if (dsp->N + dsp->K > dsp->DFT.N/2 - 2) return -1;
+    if (dsp->sample_in < dsp->delay + dsp->N + dsp->K) return -2;
 
-    dc = get_bufmu(pos-sample_out); //oder: dc = creal(X[0])/N_DFT;
+    if (pos == 0) pos = dsp->sample_out;
 
-    for (i = 0; i < N_DFT; i++) Z[i] = X[i]*Fm[i];
+    dsp->dc = get_bufmu(dsp, pos - dsp->sample_out); //oder unten: dft_dc = creal(X[0])/DFT_N;
+    // wenn richtige Stelle (Varianz pruefen, kein M10-carrier?), dann von bufs[] subtrahieren
 
-    Nidft(Z, cx);
+
+    for (i = 0; i < dsp->N + dsp->K; i++) (dsp->DFT).xn[i] = dsp->bufs[(pos+dsp->M -(dsp->N + dsp->K - 1) + i) % dsp->M];
+    while (i < (dsp->DFT).N) (dsp->DFT).xn[i++] = 0.0;
+
+    rdft(&dsp->DFT, (dsp->DFT).xn, (dsp->DFT).X);
+
+    // dft_dc = creal((dsp->DFT).X[0])/(dsp->DFT).N;
+
+    for (i = 0; i < (dsp->DFT).N; i++) (dsp->DFT).Z[i] = (dsp->DFT).X[i]*(dsp->DFT).Fm[i];
+
+    Nidft(&dsp->DFT, (dsp->DFT).Z, (dsp->DFT).cx);
 
 
     if (abs) {
-        for (i = N; i < N+K; i++) {
-            if (fabs(creal(cx[i])) > fabs(mx)) {  // imag(cx)=0
-                mx = creal(cx[i]);
+        for (i = dsp->N; i < dsp->N + dsp->K; i++) {
+            if (fabs(creal((dsp->DFT).cx[i])) > fabs(mx)) {  // imag(cx)=0
+                mx = creal((dsp->DFT).cx[i]);
                 mp = i;
             }
         }
     }
     else {
-        for (i = N; i < N+K; i++) {
-            if (creal(cx[i]) > mx) {  // imag(cx)=0
-                mx = creal(cx[i]);
+        for (i = dsp->N; i < dsp->N + dsp->K; i++) {
+            if (creal((dsp->DFT).cx[i]) > mx) {  // imag(cx)=0
+                mx = creal((dsp->DFT).cx[i]);
                 mp = i;
             }
         }
     }
-    if (mp == N || mp == N+K-1) return -4; // Randwert
+    if (mp == dsp->N || mp == dsp->N + dsp->K - 1) return -4; // Randwert
 
-    mpos = pos - ( N+K-1 - mp );
-    xnorm = sqrt(qs[(mpos + 2*M) % M]);
-    mx /= xnorm*N_DFT;
+    mpos = pos - ( dsp->N + dsp->K - 1 - mp );
+    xnorm = sqrt(dsp->qs[(mpos + 2*dsp->M) % dsp->M]);
+    mx /= xnorm*(dsp->DFT).N;
 
     *maxv = mx;
     *maxvpos = mpos;
 
-    if (pos == sample_out) buffered = sample_out-mpos;
+    if (pos == dsp->sample_out) dsp->buffered = dsp->sample_out - mpos;
 
     return mp;
 }
 
 /* ------------------------------------------------------------------------------------ */
-
-static int wav_ch = 0;  // 0: links bzw. mono; 1: rechts
 
 static int findstr(char *buff, char *str, int pos) {
     int i;
@@ -219,10 +208,11 @@ static int findstr(char *buff, char *str, int pos) {
     return i;
 }
 
-float read_wav_header(FILE *fp, float baudrate, int wav_channel) {
+float read_wav_header(pcm_t *pcm, FILE *fp) {
     char txt[4+1] = "\0\0\0\0";
     unsigned char dat[4];
     int byte, p=0;
+    int sample_rate = 0, bits_sample = 0, channels = 0;
 
     if (fread(txt, 1, 4, fp) < 4) return -1;
     if (strncmp(txt, "RIFF", 4)) return -1;
@@ -267,190 +257,191 @@ float read_wav_header(FILE *fp, float baudrate, int wav_channel) {
     fprintf(stderr, "bits       : %d\n", bits_sample);
     fprintf(stderr, "channels   : %d\n", channels);
 
-    if (wav_channel >= 0  &&  wav_channel < channels) wav_ch = wav_channel;
-    else wav_ch = 0;
-    fprintf(stderr, "channel-In : %d\n", wav_ch+1);
+    if (pcm->sel_ch < 0  ||  pcm->sel_ch >= channels) pcm->sel_ch = 0; // default channel: 0
+    fprintf(stderr, "channel-In : %d\n", pcm->sel_ch+1);
 
     if ((bits_sample != 8) && (bits_sample != 16)) return -1;
 
-    samples_per_bit = sample_rate/baudrate;
 
-    fprintf(stderr, "samples/bit: %.2f\n", samples_per_bit);
+    pcm->sr  = sample_rate;
+    pcm->bps = bits_sample;
+    pcm->nch = channels;
 
-    return samples_per_bit;
+    return 0;
 }
 
-static int f32read_sample(FILE *fp, float *s) {
+static int f32read_sample(dsp_t *dsp, float *s) {
     int i;
     short b = 0;
 
-    for (i = 0; i < channels; i++) {
+    for (i = 0; i < dsp->nch; i++) {
 
-        if (fread( &b, bits_sample/8, 1, fp) != 1) return EOF;
+        if (fread( &b, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
 
-        if (i == wav_ch) {  // i = 0: links bzw. mono
+        if (i == dsp->ch) {  // i = 0: links bzw. mono
             //if (bits_sample ==  8)  sint = b-128;   // 8bit: 00..FF, centerpoint 0x80=128
             //if (bits_sample == 16)  sint = (short)b;
 
-            if (bits_sample ==  8) { b -= 128; }
+            if (dsp->bps ==  8) { b -= 128; }
             *s = b/128.0;
-            if (bits_sample == 16) { *s /= 256.0; }
+            if (dsp->bps == 16) { *s /= 256.0; }
         }
     }
 
     return 0;
 }
 
-static int f32read_csample(FILE *fp, float complex *z) {
+static int f32read_csample(dsp_t *dsp, float complex *z) {
     short x = 0, y = 0;
 
-    if (fread( &x, bits_sample/8, 1, fp) != 1) return EOF;
-    if (fread( &y, bits_sample/8, 1, fp) != 1) return EOF;
+    if (fread( &x, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
+    if (fread( &y, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
 
     *z = x + I*y;
 
-    if (bits_sample ==  8) { *z -= 128 + I*128; }
+    if (dsp->bps ==  8) { *z -= 128 + I*128; }
     *z /= 128.0;
-    if (bits_sample == 16) { *z /= 256.0; }
+    if (dsp->bps == 16) { *z /= 256.0; }
 
     return 0;
 }
 
-float get_bufvar(int ofs) {
-    float mu  = xs[(sample_out+M + ofs) % M]/Nvar;
-    float var = qs[(sample_out+M + ofs) % M]/Nvar - mu*mu;
+float get_bufvar(dsp_t *dsp, int ofs) {
+    float mu  = dsp->xs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar;
+    float var = dsp->qs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar - mu*mu;
     return var;
 }
 
-float get_bufmu(int ofs) {
-    float mu  = xs[(sample_out+M + ofs) % M]/Nvar;
+float get_bufmu(dsp_t *dsp, int ofs) {
+    float mu  = dsp->xs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar;
     return mu;
 }
 
-int f32buf_sample(FILE *fp, int inv, int cm) {
-    float s = 0.0;
-    float xneu, xalt;
+static int get_SNR(dsp_t *dsp) {
 
-    float complex z, w;
-    static float complex z0; //= 1.0;
-    double gain = 1.0;
-
-    double t = sample_in / (double)sample_rate;
-
-
-    if (option_iq) {
-
-        if ( f32read_csample(fp, &z) == EOF ) return EOF;
-        raw_iqbuf[sample_in % N_IQBUF] = z;
-
-        z *= cexp(-t*2*M_PI*df*I);
-        w = z * conj(z0);
-        s = gain * carg(w)/M_PI;
-        z0 = z;
-        rot_iqbuf[sample_in % N_IQBUF] = z;
-
-        if (sample_posnoise > 0)
+    if (dsp->opt_iq)
+    // if(dsp->rs_typ == RS41)
+    {
+        if (dsp->sample_posnoise > 0) // rs41
         {
-            if (sample_out >= sample_posframe && sample_out < sample_posframe+len_sq) {
-                if (sample_out == sample_posframe) V_signal = 0.0;
-                V_signal += cabs(rot_iqbuf[sample_out % N_IQBUF]);
+            if (dsp->sample_out >= dsp->sample_posframe && dsp->sample_out < dsp->sample_posframe+dsp->len_sq) {
+                if (dsp->sample_out == dsp->sample_posframe) dsp->V_signal = 0.0;
+                dsp->V_signal += cabs(dsp->rot_iqbuf[dsp->sample_out % dsp->N_IQBUF]);
             }
-            if (sample_out == sample_posframe+len_sq) V_signal /= (double)len_sq;
+            if (dsp->sample_out == dsp->sample_posframe+dsp->len_sq) dsp->V_signal /= (double)dsp->len_sq;
 
-            if (sample_out >= sample_posnoise && sample_out < sample_posnoise+len_sq) {
-                if (sample_out == sample_posnoise) V_noise = 0.0;
-                V_noise += cabs(rot_iqbuf[sample_out % N_IQBUF]);
+            if (dsp->sample_out >= dsp->sample_posnoise && dsp->sample_out < dsp->sample_posnoise+dsp->len_sq) {
+                if (dsp->sample_out == dsp->sample_posnoise) dsp->V_noise = 0.0;
+                dsp->V_noise += cabs(dsp->rot_iqbuf[dsp->sample_out % dsp->N_IQBUF]);
             }
-            if (sample_out == sample_posnoise+len_sq) {
-                V_noise /= (double)len_sq;
-                if (V_signal > 0 && V_noise > 0) {
+            if (dsp->sample_out == dsp->sample_posnoise+dsp->len_sq) {
+                dsp->V_noise /= (double)dsp->len_sq;
+                if (dsp->V_signal > 0 && dsp->V_noise > 0) {
                     // iq-samples/V [-1..1]
                     // dBw = 2*dBv, P=c*U*U
                     // dBw = 2*10*log10(V/V0)
-                    SNRdB = 20.0 * log10(V_signal/V_noise+1e-20);
+                    dsp->SNRdB = 20.0 * log10(dsp->V_signal/dsp->V_noise+1e-20);
                 }
             }
         }
+    }
+    else dsp->SNRdB = 0;
+
+    return 0;
+}
+
+int f32buf_sample(dsp_t *dsp, int inv) {
+    float s = 0.0;
+    float xneu, xalt;
+
+    float complex z, w, z0;
+    //static float complex z0; //= 1.0;
+    double gain = 1.0;
+
+    double t = dsp->sample_in / (double)dsp->sr;
+
+    if (dsp->opt_iq) {
+
+        if ( f32read_csample(dsp, &z) == EOF ) return EOF;
+        dsp->raw_iqbuf[dsp->sample_in % dsp->N_IQBUF] = z;
+
+        z *= cexp(-t*2*M_PI*dsp->df*I);
+        z0 = dsp->rot_iqbuf[(dsp->sample_in-1 + dsp->N_IQBUF) % dsp->N_IQBUF];
+        w = z * conj(z0);
+        s = gain * carg(w)/M_PI;
+        //z0 = z;
+        dsp->rot_iqbuf[dsp->sample_in % dsp->N_IQBUF] = z;
+
+        get_SNR(dsp);
 
 
-        if (option_iq >= 2)
+        if (dsp->opt_iq >= 2)
         {
             double xbit = 0.0;
-            double h = 1.0; // modulation index, GFSK; h(rs41)=0.8?  // rs-depend...
-            //float complex xi = cexp(+I*M_PI*h/samples_per_bit);
-            double f1 = -h*sample_rate/(2*samples_per_bit);
+            //float complex xi = cexp(+I*M_PI*dsp->h/dsp->sps);
+            double f1 = -dsp->h*dsp->sr/(2*dsp->sps);
             double f2 = -f1;
 
             float complex X1 = 0;
             float complex X2 = 0;
 
-            int n = samples_per_bit;
+            int n = dsp->sps;
             while (n > 0) {
                 n--;
-                t = -n / (double)sample_rate;
-                z = rot_iqbuf[(sample_in - n + N_IQBUF) % N_IQBUF];  // +1
+                t = -n / (double)dsp->sr;
+                z = dsp->rot_iqbuf[(dsp->sample_in - n + dsp->N_IQBUF) % dsp->N_IQBUF];  // +1
                 X1 += z*cexp(-t*2*M_PI*f1*I);
                 X2 += z*cexp(-t*2*M_PI*f2*I);
             }
 
             xbit = cabs(X2) - cabs(X1);
 
-            s = xbit / samples_per_bit;
+            s = xbit / dsp->sps;
         }
     }
     else {
-        if (f32read_sample(fp, &s) == EOF) return EOF;
+        if (f32read_sample(dsp, &s) == EOF) return EOF;
     }
 
     if (inv) s = -s;                   // swap IQ?
-    bufs[sample_in % M] = s  - dc_ofs;
+    dsp->bufs[dsp->sample_in % dsp->M] = s - dsp->dc_ofs;
 
-    xneu = bufs[(sample_in  ) % M];
-    xalt = bufs[(sample_in+M - Nvar) % M];
-    xsum +=  xneu - xalt;                 // + xneu - xalt
-    qsum += (xneu - xalt)*(xneu + xalt);  // + xneu*xneu - xalt*xalt
-    xs[sample_in % M] = xsum;
-    qs[sample_in % M] = qsum;
-
-
-    if (0 && cm) {
-        // direct correlation
-    }
+    xneu = dsp->bufs[(dsp->sample_in  ) % dsp->M];
+    xalt = dsp->bufs[(dsp->sample_in+dsp->M - dsp->Nvar) % dsp->M];
+    dsp->xsum +=  xneu - xalt;                 // + xneu - xalt
+    dsp->qsum += (xneu - xalt)*(xneu + xalt);  // + xneu*xneu - xalt*xalt
+    dsp->xs[dsp->sample_in % dsp->M] = dsp->xsum;
+    dsp->qs[dsp->sample_in % dsp->M] = dsp->qsum;
 
 
-    sample_out = sample_in - delay;
+    dsp->sample_out = dsp->sample_in - dsp->delay;
 
-    sample_in += 1;
+    dsp->sample_in += 1;
 
     return 0;
 }
 
-static int read_bufbit(int symlen, char *bits, unsigned int mvp, int reset) {
+static int read_bufbit(dsp_t *dsp, int symlen, char *bits, ui32_t mvp, int pos) {
 // symlen==2: manchester2 0->10,1->01->1: 2.bit
 
-    static unsigned int rcount;
-    static float rbitgrenze;
+    float rbitgrenze = pos*symlen*dsp->sps;
+    ui32_t rcount = rbitgrenze+0.99; // ceil
 
     double sum = 0.0;
 
-    if (reset) {
-        rcount = 0;
-        rbitgrenze = 0;
-    }
 
-
-    rbitgrenze += samples_per_bit;
+    rbitgrenze += dsp->sps;
     do {
-        sum += bufs[(rcount + mvp + M) % M];
+        sum += dsp->bufs[(rcount + mvp + dsp->M) % dsp->M];
         rcount++;
-    } while (rcount < rbitgrenze);  // n < samples_per_bit
+    } while (rcount < rbitgrenze);  // n < dsp->sps
 
     if (symlen == 2) {
-        rbitgrenze += samples_per_bit;
+        rbitgrenze += dsp->sps;
         do {
-            sum -= bufs[(rcount + mvp + M) % M];
+            sum -= dsp->bufs[(rcount + mvp + dsp->M) % dsp->M];
             rcount++;
-        } while (rcount < rbitgrenze);  // n < samples_per_bit
+        } while (rcount < rbitgrenze);  // n < dsp->sps
     }
 
 
@@ -466,154 +457,117 @@ static int read_bufbit(int symlen, char *bits, unsigned int mvp, int reset) {
     return 0;
 }
 
-int headcmp(int symlen, char *hdr, int len, unsigned int mvp, int inv, int option_dc) {
+int headcmp(dsp_t *dsp, int symlen, ui32_t mvp, int inv, int option_dc) {
     int errs = 0;
     int pos;
     int step = 1;
     char sign = 0;
+    int len = dsp->hdrlen;
 
     if (symlen != 1) step = 2;
     if (inv) sign=1;
 
-    for (pos = 0; pos < len; pos += step) {
-        read_bufbit(symlen, rawbits+pos, mvp+1-(int)(len*samples_per_bit), pos==0);
+    for (pos = 0; pos < len; pos += step) {        // N = dsp->hdrlen * dsp->sps + 0.5;
+        //read_bufbit(dsp, symlen, dsp->rawbits+pos, mvp+1-(int)(len*dsp->sps), pos);
+        read_bufbit(dsp, symlen, dsp->rawbits+pos, mvp+1-dsp->N, pos);
     }
-    rawbits[pos] = '\0';
+    dsp->rawbits[pos] = '\0';
 
     while (len > 0) {
-        if ((rawbits[len-1]^sign) != hdr[len-1]) errs += 1;
+        if ((dsp->rawbits[len-1]^sign) != dsp->hdr[len-1]) errs += 1;
         len--;
     }
 
     if (option_dc && errs < 3) {
-        dc_ofs += dc;
+        dsp->dc_ofs += dsp->dc;
     }
 
     return errs;
 }
 
-int get_fqofs(int hdrlen, unsigned int mvp, float *freq, float *snr) {
+int get_fqofs_rs41(dsp_t *dsp, ui32_t mvp, float *freq, float *snr) {
     int j;
     int buf_start;
-    int presamples = 256*samples_per_bit;
+    int presamples;
 
-    if (presamples > M_DFT) presamples = M_DFT;
+    // if(dsp->rs_typ == RS41_PREAMBLE) ...
+    if (dsp->opt_iq)
+    {
+        presamples = 256*dsp->sps;
 
-    buf_start = mvp - hdrlen*samples_per_bit - presamples;
+        if (presamples > dsp->DFT.N2) presamples = dsp->DFT.N2;
 
-    while (buf_start < 0) buf_start += N_IQBUF;
+        buf_start = mvp - dsp->hdrlen*dsp->sps - presamples;
 
-    for (j = 0; j < M_DFT; j++) {
-       Z[j] = Hann[j]*raw_iqbuf[(buf_start+j) % N_IQBUF];
+        while (buf_start < 0) buf_start += dsp->N_IQBUF;
+
+        for (j = 0; j < dsp->DFT.N2; j++) {
+            dsp->DFT.Z[j] = dsp->DFT.win[j]*dsp->raw_iqbuf[(buf_start+j) % dsp->N_IQBUF];
+        }
+        while (j < dsp->DFT.N) dsp->DFT.Z[j++] = 0;
+
+        raw_dft(&dsp->DFT, dsp->DFT.Z);
+        dsp->df = bin2freq(&dsp->DFT, max_bin(&dsp->DFT, dsp->DFT.Z));
+
+        // if |df|<eps, +-2400Hz dominant (rs41)
+        if (fabs(dsp->df) > 1000.0) dsp->df = 0.0;
+
+
+        dsp->sample_posframe = dsp->sample_in;  // > sample_out  //mvp - dsp->hdrlen*dsp->sps;
+        dsp->sample_posnoise = mvp + dsp->sr*7/8.0; // rs41
+
+
+        *freq = dsp->df;
+        *snr = dsp->SNRdB;
     }
-    while (j < N_DFT) Z[j++] = 0;
-
-    cdft(Z);
-    df = bin2freq(max_bin(Z));
-
-    // if |df|<eps, +-2400Hz dominant (rs41)
-    if (fabs(df) > 1000.0) df = 0.0;
-
-
-    sample_posframe = sample_in;  //mvp - hdrlen*samples_per_bit;
-    sample_posnoise = mvp + sample_rate*7/8.0;
-
-
-    *freq = df;
-    *snr = SNRdB;
+    else return -1;
 
     return 0;
 }
 
 /* -------------------------------------------------------------------------- */
 
-int read_sbit(FILE *fp, int symlen, int *bit, int inv, int ofs, int reset, int cm) {
+int read_slbit(dsp_t *dsp, int symlen, int *bit, int inv, int ofs, int pos, float l) {
 // symlen==2: manchester2 10->0,01->1: 2.bit
 
-    static double bitgrenze;
-    static unsigned long scount;
-
-    float sample;
-
-    double sum = 0.0;
-
-    if (reset) {
-        scount = 0;
-        bitgrenze = 0;
-    }
-
-    if (symlen == 2) {
-        bitgrenze += samples_per_bit;
-        do {
-            if (buffered > 0) buffered -= 1;
-            else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
-
-            sample = bufs[(sample_out-buffered + ofs + M) % M];
-            sum -= sample;
-
-            scount++;
-        } while (scount < bitgrenze);  // n < samples_per_bit
-    }
-
-    bitgrenze += samples_per_bit;
-    do {
-        if (buffered > 0) buffered -= 1;
-        else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
-
-        sample = bufs[(sample_out-buffered + ofs + M) % M];
-        sum += sample;
-
-        scount++;
-    } while (scount < bitgrenze);  // n < samples_per_bit
-
-    if (sum >= 0) *bit = 1;
-    else          *bit = 0;
-
-    return 0;
-}
-
-int read_IDsbit(FILE *fp, int symlen, int *bit, int inv, int ofs, int reset, int cm) {
-// symlen==2: manchester2 10->0,01->1: 2.bit
-
-    static double bitgrenze;
-    static unsigned long scount;
+    float bitgrenze = pos*symlen*dsp->sps;
+    ui32_t scount = bitgrenze+0.99; // ceil
 
     float sample;
 
     double sum = 0.0;
     double mid;
-    double l = 1.0;
+    //double l = 0.5 .. 1.0 .. sps/2;
 
-    if (reset) {
-        scount = 0;
-        bitgrenze = 0;
-    }
 
     if (symlen == 2) {
-        mid = bitgrenze + (samples_per_bit-1)/2.0;
-        bitgrenze += samples_per_bit;
+        mid = bitgrenze + (dsp->sps-1)/2.0;
+        bitgrenze += dsp->sps;
         do {
-            if (buffered > 0) buffered -= 1;
-            else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
+            if (dsp->buffered > 0) dsp->buffered -= 1;
+            else if (f32buf_sample(dsp, inv) == EOF) return EOF;
 
-            sample = bufs[(sample_out-buffered + ofs + M) % M];
-            if (mid-l < scount && scount < mid+l) sum -= sample;
+            sample = dsp->bufs[(dsp->sample_out-dsp->buffered + ofs + dsp->M) % dsp->M];
+
+            if ( l < 0 || (mid-l < scount && scount < mid+l)) sum -= sample;
 
             scount++;
-        } while (scount < bitgrenze);  // n < samples_per_bit
+        } while (scount < bitgrenze);  // n < dsp->sps
     }
 
-    mid = bitgrenze + (samples_per_bit-1)/2.0;
-    bitgrenze += samples_per_bit;
+    mid = bitgrenze + (dsp->sps-1)/2.0;
+    bitgrenze += dsp->sps;
     do {
-        if (buffered > 0) buffered -= 1;
-        else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
+        if (dsp->buffered > 0) dsp->buffered -= 1;
+        else if (f32buf_sample(dsp, inv) == EOF) return EOF;
 
-        sample = bufs[(sample_out-buffered + ofs + M) % M];
-        if (mid-l < scount && scount < mid+l) sum += sample;
+        sample = dsp->bufs[(dsp->sample_out-dsp->buffered + ofs + dsp->M) % dsp->M];
+
+        if ( l < 0 || (mid-l < scount && scount < mid+l)) sum += sample;
 
         scount++;
-    } while (scount < bitgrenze);  // n < samples_per_bit
+    } while (scount < bitgrenze);  // n < dsp->sps
+
 
     if (sum >= 0) *bit = 1;
     else          *bit = 0;
@@ -621,90 +575,6 @@ int read_IDsbit(FILE *fp, int symlen, int *bit, int inv, int ofs, int reset, int
     return 0;
 }
 
-/* -------------------------------------------------------------------------- */
-
-int read_softbit(FILE *fp, int symlen, int *bit, float *sb, float level, int inv, int ofs, int reset, int cm) {
-// symlen==2: manchester2 10->0,01->1: 2.bit
-
-    static double bitgrenze;
-    static unsigned long scount;
-
-    float sample;
-
-    double sum = 0.0;
-    int n = 0;
-
-    if (reset) {
-        scount = 0;
-        bitgrenze = 0;
-    }
-
-    if (symlen == 2) {
-        bitgrenze += samples_per_bit;
-        do {
-            if (buffered > 0) buffered -= 1;
-            else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
-
-            sample = bufs[(sample_out-buffered + ofs + M) % M];
-            if (scount > bitgrenze-samples_per_bit  &&  scount < bitgrenze-2)
-            {
-                sum -= sample;
-                n++;
-            }
-            scount++;
-        } while (scount < bitgrenze);  // n < samples_per_bit
-    }
-
-    bitgrenze += samples_per_bit;
-    do {
-        if (buffered > 0) buffered -= 1;
-        else if (f32buf_sample(fp, inv, cm) == EOF) return EOF;
-
-        sample = bufs[(sample_out-buffered + ofs + M) % M];
-        if (scount > bitgrenze-samples_per_bit  &&  scount < bitgrenze-2)
-        {
-            sum += sample;
-            n++;
-        }
-        scount++;
-    } while (scount < bitgrenze);  // n < samples_per_bit
-
-    if (sum >= 0) *bit = 1;
-    else          *bit = 0;
-
-    *sb = sum / n;
-
-    if (*sb > +2.5*level) *sb = +0.8*level;
-    if (*sb > +level) *sb = +level;
-
-    if (*sb < -2.5*level) *sb = -0.8*level;
-    if (*sb < -level) *sb = -level;
-
-   *sb /= level;
-
-    return 0;
-}
-
-float header_level(char hdr[], int hLen, unsigned int pos, int inv) {
-    int n, bitn;
-    int sgn = 0;
-    double s = 0.0;
-    double sum = 0.0;
-
-    n = 0;
-    bitn = 0;
-    while ( bitn < hLen && (n < N) ) {
-        sgn = (hdr[bitn]&1)*2-1; // {'0','1'} -> {-1,1}
-        s = bufs[(pos-N + n + M) % M];
-        if (inv) s = -s;
-        sum += s * sgn;
-        n++;
-        bitn = n / samples_per_bit;
-    }
-    sum /= n;
-
-    return sum;
-}
 
 /* -------------------------------------------------------------------------- */
 
@@ -722,154 +592,162 @@ static double pulse(double t, double sigma) {
 }
 
 
-static double norm2_match() {
+static double norm2_vect(float *vect, int n) {
     int i;
     double x, y = 0.0;
-    for (i = 0; i < N; i++) {
-        x = match[i];
+    for (i = 0; i < n; i++) {
+        x = vect[i];
         y += x*x;
     }
     return y;
 }
 
-int init_buffers(char hdr[], int hLen, float BT, int opt_iq) {
-    //hLen = strlen(header) = HEADLEN;
+int init_buffers(dsp_t *dsp) {
 
     int i, pos;
     float b0, b1, b2, b, t;
     float normMatch;
-    double sigma = sqrt(log(2)) / (2*M_PI*BT);
+    double sigma = sqrt(log(2)) / (2*M_PI*dsp->BT);
 
-    int K;
+    int K, N, M;
     int n, k;
     float *m = NULL;
 
-    option_iq = opt_iq;
 
-    N = hLen * samples_per_bit + 0.5;
+    N = dsp->hdrlen * dsp->sps + 0.5;
     M = 3*N;
-    if (samples_per_bit < 6) M = 6*N;
-    Nvar = N; //N/2; // = N/k
-
-    bufs  = (float *)calloc( M+1, sizeof(float)); if (bufs  == NULL) return -100;
-    match = (float *)calloc( N+1, sizeof(float)); if (match == NULL) return -100;
-
-    xs = (float *)calloc( M+1, sizeof(float)); if (xs == NULL) return -100;
-    qs = (float *)calloc( M+1, sizeof(float)); if (qs == NULL) return -100;
+    if (dsp->sps < 6) M = 6*N;
 
 
-    rawbits = (char *)calloc( N+1, sizeof(char)); if (rawbits == NULL) return -100;
+    dsp->bufs  = (float *)calloc( M+1, sizeof(float)); if (dsp->bufs  == NULL) return -100;
+    dsp->match = (float *)calloc( N+1, sizeof(float)); if (dsp->match == NULL) return -100;
 
-    for (i = 0; i < M; i++) bufs[i] = 0.0;
+    dsp->xs = (float *)calloc( M+1, sizeof(float)); if (dsp->xs == NULL) return -100;
+    dsp->qs = (float *)calloc( M+1, sizeof(float)); if (dsp->qs == NULL) return -100;
+
+    dsp->rawbits = (char *)calloc( N+1, sizeof(char)); if (dsp->rawbits == NULL) return -100;
+
+
+    for (i = 0; i < M; i++) dsp->bufs[i] = 0.0;
 
 
     for (i = 0; i < N; i++) {
-        pos = i/samples_per_bit;
-        t = (i - pos*samples_per_bit)/samples_per_bit - 0.5;
+        pos = i/dsp->sps;
+        t = (i - pos*dsp->sps)/dsp->sps - 0.5;
 
-        b1 = ((hdr[pos] & 0x1) - 0.5)*2.0;
+        b1 = ((dsp->hdr[pos] & 0x1) - 0.5)*2.0;
         b = b1*pulse(t, sigma);
 
         if (pos > 0) {
-            b0 = ((hdr[pos-1] & 0x1) - 0.5)*2.0;
+            b0 = ((dsp->hdr[pos-1] & 0x1) - 0.5)*2.0;
             b += b0*pulse(t+1, sigma);
         }
 
-        if (pos < hLen) {
-            b2 = ((hdr[pos+1] & 0x1) - 0.5)*2.0;
+        if (pos < dsp->hdrlen-1) {
+            b2 = ((dsp->hdr[pos+1] & 0x1) - 0.5)*2.0;
             b += b2*pulse(t-1, sigma);
         }
 
-        match[i] = b;
+        dsp->match[i] = b;
     }
 
-    normMatch = sqrt(norm2_match());
+    normMatch = sqrt( norm2_vect(dsp->match, N) );
     for (i = 0; i < N; i++) {
-        match[i] /= normMatch;
+        dsp->match[i] /= normMatch;
     }
 
 
-    delay = N/16;
-    sample_in = 0;
+    dsp->N = N;
+    dsp->M = M;
+    dsp->Nvar = N; //N/2; // = N/k
 
-    K = M-N - delay; //N/2 - delay;  // N+K < M
+    dsp->delay = N/16;
+    dsp->sample_in = 0;
 
-    LOG2N = 2 + (int)(log(N+K)/log(2));
-    N_DFT = 1 << LOG2N;
+    K = M - N - dsp->delay; //N/2 - delay;  // N+K < M
+    dsp->K = K;
 
-    while (N + K > N_DFT/2 - 2) {
-        LOG2N  += 1;
-        N_DFT <<= 1;
+    dsp->DFT.sr = dsp->sr;
+    dsp->DFT.LOG2N = 2 + (int)(log(N+K)/log(2));
+    dsp->DFT.N = 1 << dsp->DFT.LOG2N;
+
+    while (N + K > dsp->DFT.N/2 - 2) {
+        dsp->DFT.LOG2N  += 1;
+        dsp->DFT.N <<= 1;
     }
 
+    dsp->DFT.xn = calloc(dsp->DFT.N+1, sizeof(float));  if (dsp->DFT.xn == NULL) return -1;
 
-    xn = calloc(N_DFT+1, sizeof(float));  if (xn == NULL) return -1;
+    dsp->DFT.Fm = calloc(dsp->DFT.N+1, sizeof(float complex));  if (dsp->DFT.Fm == NULL) return -1;
+    dsp->DFT.X  = calloc(dsp->DFT.N+1, sizeof(float complex));  if (dsp->DFT.X  == NULL) return -1;
+    dsp->DFT.Z  = calloc(dsp->DFT.N+1, sizeof(float complex));  if (dsp->DFT.Z  == NULL) return -1;
+    dsp->DFT.cx = calloc(dsp->DFT.N+1, sizeof(float complex));  if (dsp->DFT.cx == NULL) return -1;
 
-    ew = calloc(LOG2N+1, sizeof(float complex));  if (ew == NULL) return -1;
-    Fm = calloc(N_DFT+1, sizeof(float complex));  if (Fm == NULL) return -1;
-    X  = calloc(N_DFT+1, sizeof(float complex));  if (X  == NULL) return -1;
-    Z  = calloc(N_DFT+1, sizeof(float complex));  if (Z  == NULL) return -1;
-    cx = calloc(N_DFT+1, sizeof(float complex));  if (cx == NULL) return -1;
+    dsp->DFT.ew = calloc(dsp->DFT.LOG2N+1, sizeof(float complex));  if (dsp->DFT.ew == NULL) return -1;
 
-    M_DFT = M;
-    Hann = calloc(N_DFT+1, sizeof(float complex)); if (Hann == NULL) return -1;
-    for (i = 0; i < M_DFT; i++)  Hann[i] = 0.5 * (1 - cos( 2 * M_PI * i / (double)(M_DFT-1) ) );
+    // FFT window
+    // a) N2 = N
+    // b) N2 < N (interpolation)
+    dsp->DFT.win = calloc(dsp->DFT.N+1, sizeof(float complex));  if (dsp->DFT.win == NULL) return -1; // float real
+    dsp->DFT.N2 = dsp->DFT.N;
+    //dsp->DFT.N2 = dsp->DFT.N/2 - 1; // DFT_N=2^log2N
+    dft_window(&dsp->DFT, 1);
 
-    for (n = 0; n < LOG2N; n++) {
+    for (n = 0; n < dsp->DFT.LOG2N; n++) {
         k = 1 << n;
-        ew[n] = cexp(-I*M_PI/(float)k);
+        dsp->DFT.ew[n] = cexp(-I*M_PI/(float)k);
     }
 
-    m = calloc(N_DFT+1, sizeof(float));  if (m  == NULL) return -1;
-    for (i = 0; i < N; i++) m[N-1 - i] = match[i];
-    while (i < N_DFT) m[i++] = 0.0;
-    rdft(m, Fm);
+    m = calloc(dsp->DFT.N+1, sizeof(float));  if (m  == NULL) return -1;
+    for (i = 0; i < N; i++) m[N-1 - i] = dsp->match[i];
+    while (i < dsp->DFT.N) m[i++] = 0.0;
+    rdft(&dsp->DFT, m, dsp->DFT.Fm);
 
     free(m); m = NULL;
 
 
-    if (option_iq)
+    if (dsp->opt_iq)
     {
-        if (channels < 2) return -1;
+        if (dsp->nch < 2) return -1;
 /*
-        M_DFT = samples_per_bit*256+0.5;
-        while ( (1 << LOG2N) < M_DFT ) LOG2N++;
+        N2 = dsp->sps*256+0.5;
+        while ( (1 << LOG2N) < N2 ) LOG2N++;
         LOG2N++;
-        N_DFT = (1 << LOG2N);
-        N_IQBUF = M_DFT + samples_per_bit*(64+16);
+        N = (1 << LOG2N);
+        N_IQBUF = N2 + sps*(64+16);
 */
-        N_IQBUF = N_DFT;
-        raw_iqbuf = calloc(N_IQBUF+1, sizeof(float complex));  if (raw_iqbuf == NULL) return -1;
-        rot_iqbuf = calloc(N_IQBUF+1, sizeof(float complex));  if (rot_iqbuf == NULL) return -1;
+        dsp->N_IQBUF = dsp->DFT.N;
+        dsp->raw_iqbuf = calloc(dsp->N_IQBUF+1, sizeof(float complex));  if (dsp->raw_iqbuf == NULL) return -1;
+        dsp->rot_iqbuf = calloc(dsp->N_IQBUF+1, sizeof(float complex));  if (dsp->rot_iqbuf == NULL) return -1;
 
-        len_sq = samples_per_bit*8;
+        dsp->len_sq = dsp->sps*8;
     }
 
 
     return K;
 }
 
-int free_buffers() {
+int free_buffers(dsp_t *dsp) {
 
-    if (match) { free(match); match = NULL; }
-    if (bufs)  { free(bufs);  bufs  = NULL; }
-    if (xs)  { free(xs);  xs  = NULL; }
-    if (qs)  { free(qs);  qs  = NULL; }
-    if (rawbits) { free(rawbits); rawbits = NULL; }
+    if (dsp->match) { free(dsp->match); dsp->match = NULL; }
+    if (dsp->bufs)  { free(dsp->bufs);  dsp->bufs  = NULL; }
+    if (dsp->xs)  { free(dsp->xs);  dsp->xs  = NULL; }
+    if (dsp->qs)  { free(dsp->qs);  dsp->qs  = NULL; }
+    if (dsp->rawbits) { free(dsp->rawbits); dsp->rawbits = NULL; }
 
-    if (xn) { free(xn); xn = NULL; }
-    if (ew) { free(ew); ew = NULL; }
-    if (Fm) { free(Fm); Fm = NULL; }
-    if (X)  { free(X);  X  = NULL; }
-    if (Z)  { free(Z);  Z  = NULL; }
-    if (cx) { free(cx); cx = NULL; }
+    if (dsp->DFT.xn) { free(dsp->DFT.xn); dsp->DFT.xn = NULL; }
+    if (dsp->DFT.ew) { free(dsp->DFT.ew); dsp->DFT.ew = NULL; }
+    if (dsp->DFT.Fm) { free(dsp->DFT.Fm); dsp->DFT.Fm = NULL; }
+    if (dsp->DFT.X)  { free(dsp->DFT.X);  dsp->DFT.X  = NULL; }
+    if (dsp->DFT.Z)  { free(dsp->DFT.Z);  dsp->DFT.Z  = NULL; }
+    if (dsp->DFT.cx) { free(dsp->DFT.cx); dsp->DFT.cx = NULL; }
 
-    if (Hann) { free(Hann); Hann = NULL; }
+    if (dsp->DFT.win) { free(dsp->DFT.win); dsp->DFT.win = NULL; }
 
-    if (option_iq)
+    if (dsp->opt_iq)
     {
-        if (raw_iqbuf)  { free(raw_iqbuf); raw_iqbuf = NULL; }
-        if (rot_iqbuf)  { free(rot_iqbuf); rot_iqbuf = NULL; }
+        if (dsp->raw_iqbuf)  { free(dsp->raw_iqbuf); dsp->raw_iqbuf = NULL; }
+        if (dsp->rot_iqbuf)  { free(dsp->rot_iqbuf); dsp->rot_iqbuf = NULL; }
     }
 
     return 0;
@@ -877,7 +755,7 @@ int free_buffers() {
 
 /* ------------------------------------------------------------------------------------ */
 
-unsigned int get_sample() {
-    return sample_out;
+ui32_t get_sample(dsp_t *dsp) {
+    return dsp->sample_out;
 }
 

--- a/demod/demod_iq.h
+++ b/demod/demod_iq.h
@@ -1,19 +1,115 @@
 
-float read_wav_header(FILE*, float, int);
-int f32buf_sample(FILE*, int, int);
-int read_sbit(FILE*, int, int*, int, int, int, int);
-int read_IDsbit(FILE*, int, int*, int, int, int, int);
-int read_softbit(FILE *fp, int symlen, int *bit, float *sb, float level, int inv, int ofs, int reset, int cm);
-float header_level(char hdr[], int hLen, unsigned int pos, int inv);
 
-int getCorrDFT(int, int, unsigned int, float *, unsigned int *);
-int headcmp(int, char*, int, unsigned int, int, int);
-int get_fqofs(int, unsigned int, float *, float *);
-float get_bufvar(int);
-float get_bufmu(int);
+#include <math.h>
+#include <complex.h>
 
-int init_buffers(char*, int, float, int);
-int free_buffers(void);
+typedef unsigned char  ui8_t;
+typedef unsigned short ui16_t;
+typedef unsigned int   ui32_t;
+typedef char  i8_t;
+typedef short i16_t;
+typedef int   i32_t;
 
-unsigned int get_sample(void);
+
+typedef struct {
+    int sr;       // sample_rate
+    int LOG2N;
+    int N;
+    int N2;
+    float *xn;
+    float complex  *ew;
+    float complex  *Fm;
+    float complex  *X;
+    float complex  *Z;
+    float complex  *cx;
+    float complex  *win; // float real
+} dft_t;
+
+
+typedef struct {
+    FILE *fp;
+    //
+    int sr;       // sample_rate
+    int bps;      // bits/sample
+    int nch;      // channels
+    int ch;       // select channel
+    //
+    int symlen;
+    float sps;    // samples per symbol
+    float _spb;   // samples per bit
+    float br;     // baud rate
+    //
+    ui32_t sample_in;
+    ui32_t sample_out;
+    ui32_t delay;
+    int buffered;
+    int N;
+    int M;
+    int K;
+    float *match;
+    float *bufs;
+    float dc_ofs;
+    float dc;
+    //
+    int N_norm;
+    int Nvar;
+    float xsum;
+    float qsum;
+    float *xs;
+    float *qs;
+
+    // IQ-data
+    int opt_iq;
+    int N_IQBUF;
+    float complex *raw_iqbuf;
+    float complex *rot_iqbuf;
+
+    //
+    char *rawbits;
+    char *hdr;
+    int hdrlen;
+
+    //
+    float BT; // bw/time (ISI)
+    float h;  // modulation index
+
+    // DFT
+    dft_t DFT;
+
+    double df;
+    int len_sq;
+
+    ui32_t sample_posframe;
+    ui32_t sample_posnoise;
+
+    double V_noise;
+    double V_signal;
+    double SNRdB;
+
+} dsp_t;
+
+
+typedef struct {
+    int sr;       // sample_rate
+    int bps;      // bits_sample  bits/sample
+    int nch;      // channels
+    int sel_ch;   // select wav channel
+} pcm_t;
+
+
+
+float read_wav_header(pcm_t *, FILE *);
+int f32buf_sample(dsp_t *, int);
+int read_slbit(dsp_t *, int, int*, int, int, int, float);
+
+int getCorrDFT(dsp_t *, int, ui32_t, float *, ui32_t *);
+int headcmp(dsp_t *, int, ui32_t, int, int);
+int get_fqofs_rs41(dsp_t *, ui32_t, float *, float *);
+float get_bufvar(dsp_t *, int);
+float get_bufmu(dsp_t *, int);
+
+int init_buffers(dsp_t *);
+int free_buffers(dsp_t *);
+
+ui32_t get_sample(dsp_t *);
 

--- a/demod/m10dm_dft.c
+++ b/demod/m10dm_dft.c
@@ -781,6 +781,8 @@ int print_frame(int pos) {
 
 int main(int argc, char **argv) {
 
+    int spike = 0;
+
     FILE *fp = NULL;
     char *fpname = NULL;
     float spb = 0.0;
@@ -840,6 +842,9 @@ int main(int argc, char **argv) {
         }
         else if ( (strcmp(*argv, "--dc") == 0) ) {
             option_dc = 1;
+        }
+        else if ( (strcmp(*argv, "--spike") == 0) ) {
+            spike = 1;
         }
         else if ( (strcmp(*argv, "--ch2") == 0) ) { wav_channel = 1; }  // right channel (default: 0=left)
         else if ( (strcmp(*argv, "--ths") == 0) ) {
@@ -906,8 +911,8 @@ int main(int argc, char **argv) {
                 herrs = headcmp(1, rawheader, headerlen, mv_pos, mv<0, option_dc); // header nicht manchester!
                 herr1 = 0;
                 if (herrs <= 3 && herrs > 0) {
-                    herr1 = headcmp(1, rawheader, headerlen, mv_pos+1, mv<0, option_dc);
-                    //int herr2 = headcmp(1, rawheader, headerlen, mv_pos-1, mv<0, option_dc);
+                    herr1 = headcmp(1, rawheader, headerlen, mv_pos+1, mv<0, 0); // nur 1x dc
+                    //int herr2 = headcmp(1, rawheader, headerlen, mv_pos-1, mv<0, 0);
                     if (herr1 < herrs) {
                         herrs = herr1;
                         herr1 = 1;
@@ -924,7 +929,7 @@ int main(int argc, char **argv) {
 
                     while ( pos < BITFRAME_LEN+BITAUX_LEN ) {
                         header_found = !(pos>=BITFRAME_LEN-10);
-                        bitQ = read_sbit(fp, symlen, &bit, option_inv, bitofs, bitpos==0, !header_found); // symlen=2, return: zeroX/bit
+                        bitQ = read_spkbit(fp, symlen, &bit, option_inv, bitofs, bitpos==0, !header_found, spike); // symlen=2, return: zeroX/bit
                         if (bitQ == EOF) { break; }
                         frame_bits[pos] = 0x31 ^ (bit0 ^ bit);
                         pos++;
@@ -940,7 +945,7 @@ int main(int argc, char **argv) {
                     // bis Ende der Sekunde vorspulen; allerdings Doppel-Frame alle 10 sek
                     if (option_verbose < 3) { // && (regulare frame) // print_frame-return?
                         while ( bitpos < 5*BITFRAME_LEN ) {
-                            bitQ = read_sbit(fp, symlen, &bit, option_inv, bitofs, bitpos==0, 0); // symlen=2, return: zeroX/bit
+                            bitQ = read_spkbit(fp, symlen, &bit, option_inv, bitofs, bitpos==0, 0, spike); // symlen=2, return: zeroX/bit
                             if ( bitQ == EOF) break;
                             bitpos++;
                         }


### PR DESCRIPTION
This PR switches auto_rx to using dft_detect. While we haven't really checked the performance differences when using rtl_fm, tests using csdr as a FM demodulator show significantly improved detection performance, and no issues with mis-detections.