### PR TITLE
Speedups to dft_detect

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -5,7 +5,7 @@
 #   Copyright (C) 2018  Mark Jessop <vk5qi@rfhead.net>
 #   Released under GNU GPL v3 or later
 #
-__version__ = "20190227-beta"
+__version__ = "20190228-beta"
 
 # Global Variables
 

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -4,7 +4,7 @@
 #
 
 # Build rs_detect.
-echo "Building rs_detect"
+echo "Building dft_detect"
 cd ../scan/
 gcc dft_detect.c -lm -o dft_detect -DNOC34C50
 

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -6,7 +6,7 @@
 # Build rs_detect.
 echo "Building rs_detect"
 cd ../scan/
-gcc dft_detect.c -lm -o dft_detect
+gcc dft_detect.c -lm -o dft_detect -DNOC34C50
 
 echo "Building RS92/RS41/DFM Demodulators"
 cd ../demod/

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -10,6 +10,7 @@ import glob
 import argparse
 import os
 import sys
+import time
 import subprocess
 
 
@@ -97,7 +98,7 @@ processing_type = {
         # Decimate to a 24 kHz bandwidth, demodulator, then interpolate back up to 48 kHz.
         'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null| ",
         # Decode using rs41ecc
-        'decode': "../dft_detect 2>/dev/null",
+        'decode': "../dft_detect3 2>/dev/null",
         # Grep out the line containing the detected sonde type.
         "post_process" : " | grep \:"
     },
@@ -134,7 +135,7 @@ processing_type = {
 
 
 
-def run_analysis(mode, file_list, shift=0.0):
+def run_analysis(mode, file_list, shift=0.0, verbose=False):
 
     _mode = processing_type[mode]
 
@@ -163,11 +164,17 @@ def run_analysis(mode, file_list, shift=0.0):
 
         # Run the command.
         try:
+            _start = time.time()
             _output = subprocess.check_output(_cmd, shell=True, stderr=None)
         except:
             _output = "error"
 
+        _runtime = time.time() - _start
+
         print("%s, %s" % (os.path.basename(_file), _output.strip()))
+
+        if verbose:
+            print("Runtime: %.1d" % _runtime)
 
 
 
@@ -176,6 +183,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-m", "--mode", type=str, default="rs41_csdr_fm_decode", help="Operation mode.")
     parser.add_argument("-f", "--files", type=str, default="./generated/*.bin", help="Glob-path to files to run over.")
+    parser.add_argument("-v", "--verbose", action='store_true', default=False, help="Show additional debug info.")
     parser.add_argument("--shift", type=float, default=0.0, help="Shift the signal-under test by x Hz. Default is 0.")
     args = parser.parse_args()
 
@@ -195,4 +203,4 @@ if __name__ == "__main__":
     # Sort the list of files.
     _file_list.sort()
 
-    run_analysis(args.mode, _file_list, shift=args.shift)
+    run_analysis(args.mode, _file_list, shift=args.shift, verbose=args.verbose)

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -98,7 +98,7 @@ processing_type = {
         # Decimate to a 24 kHz bandwidth, demodulator, then interpolate back up to 48 kHz.
         'demod' : "| csdr fir_decimate_cc 4 0.005 HAMMING 2>/dev/null | csdr fmdemod_quadri_cf | csdr limit_ff | csdr rational_resampler_ff 2 1 0.005 HAMMING | csdr convert_f_s16 | sox -t raw -r 48k -e signed-integer -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null| ",
         # Decode using rs41ecc
-        'decode': "../dft_detect3 2>/dev/null",
+        'decode': "../dft_detect 2>/dev/null",
         # Grep out the line containing the detected sonde type.
         "post_process" : " | grep \:"
     },

--- a/scan/dft_detect.c
+++ b/scan/dft_detect.c
@@ -547,8 +547,8 @@ static int init_buffers() {
     M -= 1;
     N_DFT <<= 1;
 #endif
-    LOG2N = log(N_DFT)/log(2);
-    //while ((1 << LOG2N) < N_DFT) LOGN++;
+    LOG2N = log(N_DFT)/log(2)+0.1; // 32bit cpu ... intermediate floating-point precision
+    //while ((1 << LOG2N) < N_DFT) LOG2N++;  // better N_DFT = (1 << LOG2N) ...
 
     K = M-NN - delay; // N+K < M
 

--- a/scan/dft_detect.c
+++ b/scan/dft_detect.c
@@ -238,8 +238,12 @@ static int getCorrDFT(int abs, int K, unsigned int pos, float *maxv, unsigned in
 
     dc = 0.0;
 
+#ifdef ZEROPAD
     if (rshd.N + K > N_DFT/2 - 2) return -1;
-    if (sample_in < delay+rshd.N+K) return -2;
+#else
+    if (rshd.N + K > N_DFT) return -1;
+#endif
+//    if (sample_in < delay+rshd.N+K) return -2;
 
     if (pos == 0) pos = sample_out;
 
@@ -379,7 +383,7 @@ static int f32read_sample(FILE *fp, float *s) {
 }
 
 
-static int f32buf_sample(FILE *fp, int inv, int cm) {
+static int f32buf_sample(FILE *fp, int inv) {
     float s = 0.0;
     float xneu, xalt;
 
@@ -397,11 +401,6 @@ static int f32buf_sample(FILE *fp, int inv, int cm) {
     qsum += (xneu - xalt)*(xneu + xalt);  // + xneu*xneu - xalt*xalt
     qs[sample_in % M] = qsum;
 */
-
-    if (0 && cm) {
-        // direct correlation
-    }
-
 
     sample_out = sample_in - delay;
 
@@ -510,6 +509,7 @@ static int init_buffers() {
     double b0, b1, b2, b;
     float normMatch;
 
+    int p2 = 1;
     int K, NN;
     int n, k;
     float *match = NULL;
@@ -532,21 +532,25 @@ static int init_buffers() {
 
     NN = hLen * sample_rate/2500.0 + 0.5; // max(hLen*spb)
 
-    M = 3*NN;
+    M = 2*NN;
     //if (samples_per_bit < 6) M = 6*N;
 
     delay = NN/16;
     sample_in = 0;
 
+    p2 = 1;
+    while (p2 < M) p2 <<= 1;
+    while (p2 < 0x2000) p2 <<= 1;  // or 0x4000, if sample not too short
+    M = p2;
+    N_DFT = p2;
+#ifdef ZEROPAD
+    M -= 1;
+    N_DFT <<= 1;
+#endif
+    LOG2N = log(N_DFT)/log(2);
+    //while ((1 << LOG2N) < N_DFT) LOGN++;
+
     K = M-NN - delay; // N+K < M
-
-    LOG2N = 2 + (int)(log(NN+K)/log(2));
-    N_DFT = 1 << LOG2N;
-
-    while (NN + K > N_DFT/2 - 2) {
-        LOG2N  += 1;
-        N_DFT <<= 1;
-    }
 
     Nvar = NN; // wenn Nvar fuer xnorm, dann Nvar=rshd.N
 
@@ -736,7 +740,7 @@ int main(int argc, char **argv) {
 
     k = 0;
 
-    while ( f32buf_sample(fp, option_inv, 1) != EOF ) {
+    while ( f32buf_sample(fp, option_inv) != EOF ) {
 
         if (tl > 0 && sample_in > (tl+1)*sample_rate) break;  // (int)sample_out < 0
 
@@ -744,6 +748,9 @@ int main(int argc, char **argv) {
 
         if (k >= K-4) {
             for (j = 0; j < Nrs-2; j++) {
+#ifdef NOC34C50
+                if ( strncmp(rs_hdr[j].type, "C34C50", 6) == 0 ) continue;
+#endif
                 mv0_pos[j] = mv_pos[j];
                 mp[j] = getCorrDFT(-1, K, 0, mv+j, mv_pos+j, rs_hdr[j]);
             }
@@ -779,7 +786,7 @@ int main(int argc, char **argv) {
                             n = 0;
                             while (n < sample_rate) { // 1 sec
 
-                                if (f32buf_sample(fp, option_inv, 1) == EOF) break;//goto ende;
+                                if (f32buf_sample(fp, option_inv) == EOF) break;//goto ende;
 
                                 xn[n % D] = bufs[sample_out % M];
                                 n++;
@@ -821,7 +828,7 @@ int main(int argc, char **argv) {
 
                                 // detect header/polarity
                                 k = 0;
-                                while ( n < 4*sample_rate && f32buf_sample(fp, option_inv, 1) != EOF ) {
+                                while ( n < 4*sample_rate && f32buf_sample(fp, option_inv) != EOF ) {
 
                                     n += 1;
                                     k += 1;


### PR DESCRIPTION
~3x speedup, no change in detection performance.

Comparison of pre-update and post-update performance follows:

Old dft_detect
--------------
dfm09_96k_float_10.0dB.bin, error
Runtime: 27
dfm09_96k_float_10.5dB.bin, error
Runtime: 27
dfm09_96k_float_11.0dB.bin, error
Runtime: 27
dfm09_96k_float_11.5dB.bin, error
Runtime: 27
dfm09_96k_float_12.0dB.bin, error
Runtime: 27
dfm09_96k_float_12.5dB.bin, error
Runtime: 27
dfm09_96k_float_13.0dB.bin, error
Runtime: 27
dfm09_96k_float_13.5dB.bin, error
Runtime: 27
dfm09_96k_float_14.0dB.bin, error
Runtime: 27
dfm09_96k_float_14.5dB.bin, error
Runtime: 27
dfm09_96k_float_15.0dB.bin, error
Runtime: 27
dfm09_96k_float_15.5dB.bin, DFM9: 0.6543
Runtime: 17
dfm09_96k_float_16.0dB.bin, DFM9: 0.6741
Runtime: 5
dfm09_96k_float_16.5dB.bin, DFM9: 0.6530
Runtime: 3
dfm09_96k_float_17.0dB.bin, DFM9: 0.6838
Runtime: 2
dfm09_96k_float_17.5dB.bin, DFM9: 0.6965
Runtime: 2
dfm09_96k_float_18.0dB.bin, DFM9: 0.6611
Runtime: 2
dfm09_96k_float_18.5dB.bin, DFM9: 0.7499
Runtime: 2
dfm09_96k_float_19.0dB.bin, DFM9: 0.7730
Runtime: 2
dfm09_96k_float_19.5dB.bin, DFM9: 0.7552
Runtime: 3
m10_96k_float_10.0dB.bin, M10: -0.7766
Runtime: 3
m10_96k_float_10.5dB.bin, M10: 0.8284
Runtime: 3
m10_96k_float_11.0dB.bin, M10: -0.7642
Runtime: 3
m10_96k_float_11.5dB.bin, M10: -0.8161
Runtime: 3
m10_96k_float_12.0dB.bin, M10: -0.8275
Runtime: 3
m10_96k_float_12.5dB.bin, M10: -0.8462
Runtime: 2
m10_96k_float_13.0dB.bin, M10: -0.8832
Runtime: 4
m10_96k_float_13.5dB.bin, M10: -0.8071
Runtime: 3
m10_96k_float_14.0dB.bin, M10: -0.8111
Runtime: 2
m10_96k_float_14.5dB.bin, M10: -0.8956
Runtime: 3
m10_96k_float_15.0dB.bin, M10: -0.9138
Runtime: 3
m10_96k_float_15.5dB.bin, M10: -0.9118
Runtime: 2
m10_96k_float_16.0dB.bin, M10: -0.9294
Runtime: 2
m10_96k_float_16.5dB.bin, M10: -0.9378
Runtime: 2
m10_96k_float_17.0dB.bin, M10: -0.9434
Runtime: 3
m10_96k_float_17.5dB.bin, M10: -0.9347
Runtime: 3
m10_96k_float_18.0dB.bin, M10: -0.9587
Runtime: 3
m10_96k_float_18.5dB.bin, M10: -0.9450
Runtime: 5
m10_96k_float_19.0dB.bin, M10: -0.9608
Runtime: 3
m10_96k_float_19.5dB.bin, M10: -0.9617
Runtime: 2
rs41_96k_float_10.0dB.bin, error
Runtime: 26
rs41_96k_float_10.5dB.bin, error
Runtime: 26
rs41_96k_float_11.0dB.bin, error
Runtime: 26
rs41_96k_float_11.5dB.bin, error
Runtime: 26
rs41_96k_float_12.0dB.bin, error
Runtime: 26
rs41_96k_float_12.5dB.bin, error
Runtime: 26
rs41_96k_float_13.0dB.bin, error
Runtime: 26
rs41_96k_float_13.5dB.bin, error
Runtime: 26
rs41_96k_float_14.0dB.bin, error
Runtime: 26
rs41_96k_float_14.5dB.bin, RS41: 0.7008
Runtime: 8
rs41_96k_float_15.0dB.bin, RS41: 0.7042
Runtime: 3
rs41_96k_float_15.5dB.bin, RS41: 0.7212
Runtime: 3
rs41_96k_float_16.0dB.bin, RS41: 0.7306
Runtime: 3
rs41_96k_float_16.5dB.bin, RS41: 0.7190
Runtime: 3
rs41_96k_float_17.0dB.bin, RS41: 0.7378
Runtime: 3
rs41_96k_float_17.5dB.bin, RS41: 0.7828
Runtime: 3
rs41_96k_float_18.0dB.bin, RS41: 0.7965
Runtime: 3
rs41_96k_float_18.5dB.bin, RS41: 0.8225
Runtime: 3
rs41_96k_float_19.0dB.bin, RS41: 0.8380
Runtime: 3
rs41_96k_float_19.5dB.bin, RS41: 0.8632
Runtime: 3
rs92_96k_float_10.0dB.bin, error
Runtime: 26
rs92_96k_float_10.5dB.bin, error
Runtime: 26
rs92_96k_float_11.0dB.bin, error
Runtime: 26
rs92_96k_float_11.5dB.bin, error
Runtime: 26
rs92_96k_float_12.0dB.bin, error
Runtime: 27
rs92_96k_float_12.5dB.bin, error
Runtime: 26
rs92_96k_float_13.0dB.bin, error
Runtime: 26
rs92_96k_float_13.5dB.bin, error
Runtime: 26
rs92_96k_float_14.0dB.bin, error
Runtime: 26
rs92_96k_float_14.5dB.bin, error
Runtime: 27
rs92_96k_float_15.0dB.bin, error
Runtime: 27
rs92_96k_float_15.5dB.bin, error
Runtime: 26
rs92_96k_float_16.0dB.bin, error
Runtime: 27
rs92_96k_float_16.5dB.bin, error
Runtime: 27
rs92_96k_float_17.0dB.bin, RS92: 0.7318
Runtime: 3
rs92_96k_float_17.5dB.bin, RS92: 0.7051
Runtime: 7
rs92_96k_float_18.0dB.bin, RS92: 0.7003
Runtime: 2
rs92_96k_float_18.5dB.bin, RS92: 0.7335
Runtime: 2
rs92_96k_float_19.0dB.bin, RS92: 0.7721
Runtime: 3
rs92_96k_float_19.5dB.bin, RS92: 0.7851
Runtime: 2

New dft_detect with -DNOC34C50
------------------------------
dfm09_96k_float_10.0dB.bin, error
Runtime: 9
dfm09_96k_float_10.5dB.bin, error
Runtime: 10
dfm09_96k_float_11.0dB.bin, error
Runtime: 9
dfm09_96k_float_11.5dB.bin, error
Runtime: 9
dfm09_96k_float_12.0dB.bin, error
Runtime: 9
dfm09_96k_float_12.5dB.bin, error
Runtime: 9
dfm09_96k_float_13.0dB.bin, error
Runtime: 9
dfm09_96k_float_13.5dB.bin, error
Runtime: 9
dfm09_96k_float_14.0dB.bin, error
Runtime: 10
dfm09_96k_float_14.5dB.bin, error
Runtime: 9
dfm09_96k_float_15.0dB.bin, error
Runtime: 9
dfm09_96k_float_15.5dB.bin, DFM9: 0.6543
Runtime: 7
dfm09_96k_float_16.0dB.bin, DFM9: 0.6740
Runtime: 3
dfm09_96k_float_16.5dB.bin, DFM9: 0.6529
Runtime: 3
dfm09_96k_float_17.0dB.bin, DFM9: 0.6838
Runtime: 3
dfm09_96k_float_17.5dB.bin, DFM9: 0.6965
Runtime: 3
dfm09_96k_float_18.0dB.bin, DFM9: 0.6611
Runtime: 5
dfm09_96k_float_18.5dB.bin, DFM9: 0.7499
Runtime: 4
dfm09_96k_float_19.0dB.bin, DFM9: 0.7730
Runtime: 4
dfm09_96k_float_19.5dB.bin, DFM9: 0.7551
Runtime: 3
m10_96k_float_10.0dB.bin, M10: -0.7765
Runtime: 3
m10_96k_float_10.5dB.bin, M10: 0.8284
Runtime: 3
m10_96k_float_11.0dB.bin, M10: -0.7642
Runtime: 3
m10_96k_float_11.5dB.bin, M10: -0.8160
Runtime: 3
m10_96k_float_12.0dB.bin, M10: -0.8275
Runtime: 2
m10_96k_float_12.5dB.bin, M10: -0.8462
Runtime: 2
m10_96k_float_13.0dB.bin, M10: -0.8832
Runtime: 2
m10_96k_float_13.5dB.bin, M10: -0.8070
Runtime: 2
m10_96k_float_14.0dB.bin, M10: -0.8111
Runtime: 2
m10_96k_float_14.5dB.bin, M10: -0.8955
Runtime: 2
m10_96k_float_15.0dB.bin, M10: -0.9137
Runtime: 2
m10_96k_float_15.5dB.bin, M10: -0.9118
Runtime: 2
m10_96k_float_16.0dB.bin, M10: -0.9294
Runtime: 2
m10_96k_float_16.5dB.bin, M10: -0.9378
Runtime: 2
m10_96k_float_17.0dB.bin, M10: -0.9434
Runtime: 2
m10_96k_float_17.5dB.bin, M10: -0.9347
Runtime: 2
m10_96k_float_18.0dB.bin, M10: -0.9586
Runtime: 2
m10_96k_float_18.5dB.bin, M10: -0.9449
Runtime: 2
m10_96k_float_19.0dB.bin, M10: -0.9607
Runtime: 2
m10_96k_float_19.5dB.bin, M10: -0.9617
Runtime: 2
rs41_96k_float_10.0dB.bin, error
Runtime: 9
rs41_96k_float_10.5dB.bin, error
Runtime: 9
rs41_96k_float_11.0dB.bin, error
Runtime: 10
rs41_96k_float_11.5dB.bin, error
Runtime: 9
rs41_96k_float_12.0dB.bin, error
Runtime: 9
rs41_96k_float_12.5dB.bin, error
Runtime: 10
rs41_96k_float_13.0dB.bin, error
Runtime: 9
rs41_96k_float_13.5dB.bin, error
Runtime: 9
rs41_96k_float_14.0dB.bin, error
Runtime: 9
rs41_96k_float_14.5dB.bin, RS41: 0.7008
Runtime: 4
rs41_96k_float_15.0dB.bin, RS41: 0.7042
Runtime: 3
rs41_96k_float_15.5dB.bin, RS41: 0.7212
Runtime: 2
rs41_96k_float_16.0dB.bin, RS41: 0.7305
Runtime: 2
rs41_96k_float_16.5dB.bin, RS41: 0.7190
Runtime: 2
rs41_96k_float_17.0dB.bin, RS41: 0.7378
Runtime: 2
rs41_96k_float_17.5dB.bin, RS41: 0.7827
Runtime: 2
rs41_96k_float_18.0dB.bin, RS41: 0.7965
Runtime: 2
rs41_96k_float_18.5dB.bin, RS41: 0.8225
Runtime: 2
rs41_96k_float_19.0dB.bin, RS41: 0.8380
Runtime: 2
rs41_96k_float_19.5dB.bin, RS41: 0.8631
Runtime: 2
rs92_96k_float_10.0dB.bin, error
Runtime: 9
rs92_96k_float_10.5dB.bin, error
Runtime: 9
rs92_96k_float_11.0dB.bin, error
Runtime: 9
rs92_96k_float_11.5dB.bin, error
Runtime: 9
rs92_96k_float_12.0dB.bin, error
Runtime: 9
rs92_96k_float_12.5dB.bin, error
Runtime: 9
rs92_96k_float_13.0dB.bin, error
Runtime: 10
rs92_96k_float_13.5dB.bin, error
Runtime: 9
rs92_96k_float_14.0dB.bin, error
Runtime: 9
rs92_96k_float_14.5dB.bin, error
Runtime: 9
rs92_96k_float_15.0dB.bin, error
Runtime: 9
rs92_96k_float_15.5dB.bin, error
Runtime: 9
rs92_96k_float_16.0dB.bin, error
Runtime: 9
rs92_96k_float_16.5dB.bin, error
Runtime: 9
rs92_96k_float_17.0dB.bin, RS92: 0.7318
Runtime: 3
rs92_96k_float_17.5dB.bin, RS92: 0.7051
Runtime: 4
rs92_96k_float_18.0dB.bin, RS92: 0.7003
Runtime: 2
rs92_96k_float_18.5dB.bin, RS92: 0.7334
Runtime: 2
rs92_96k_float_19.0dB.bin, RS92: 0.7721
Runtime: 2
rs92_96k_float_19.5dB.bin, RS92: 0.7851
Runtime: 2