### PR TITLE
GPS satellites number and battery level

### DIFF
--- a/m10/M10GtopParser.cpp
+++ b/m10/M10GtopParser.cpp
@@ -192,6 +192,16 @@ std::string M10GtopParser::getSerialNumber() {
         sn_bytes[i] = byte;
     }
 
+    /*
+     * The serial number is in the form M10-A-BCC-D-EEEE
+     * - A is the frame type, T for Trimble, the original GPS used for this modulation
+     * G for Gtop GPS
+     * - B is the year of fabrication (8 = 2018)
+     * - CC is the month of fabrication
+     * - D is the product type, 2 is production type
+     * - EEEE is the RS serial number
+     */
+
     byte = sn_bytes[2];
     sprintf(SN, "M10-G-%1X%02u", (byte >> 4)&0xF, byte & 0xF);
     byte = sn_bytes[3] | (sn_bytes[4] << 8);

--- a/m10/M10TrimbleParser.cpp
+++ b/m10/M10TrimbleParser.cpp
@@ -454,7 +454,7 @@ void M10TrimbleParser::printFrame() {
                 "\"dxlid\": \"%s\", "
                 "\"datetime\": \"%04d-%02d-%02dT%02d:%02d:%02dZ\", "
                 "%s" // Aux data
-                "\"satelites\": %d, "
+                "\"satellites\": %d, "
                 "\"lat\": %.5f, "
                 "\"lon\": %.5f, "
                 "\"alt\": %.2f, "

--- a/m10/M10TrimbleParser.cpp
+++ b/m10/M10TrimbleParser.cpp
@@ -144,6 +144,14 @@ int M10TrimbleParser::getSeconds() {
     return (time / 1000 % (24 * 3600)) % 60;
 }
 
+int M10TrimbleParser::getSatellites() {
+    unsigned char sats;
+
+    sats = frame_bytes[30];
+
+    return sats;
+}
+
 double M10TrimbleParser::getVerticalSpeed() {
     int i;
     unsigned byte;
@@ -296,6 +304,15 @@ double M10TrimbleParser::getDp() {
     return 0;
 }
 
+double M10TrimbleParser::getBatteryLevel() {
+    unsigned short batLvl;
+    
+    batLvl = (frame_bytes[70] << 8) | frame_bytes[69];
+    
+    // Thanks F5MVO for the formula !
+    return (double)batLvl/1000.*6.62;
+}
+
 std::string M10TrimbleParser::getSerialNumber() {
     int i;
     unsigned byte;
@@ -311,6 +328,16 @@ std::string M10TrimbleParser::getSerialNumber() {
         sn_bytes[i] = byte;
     }
 
+    /*
+     * The serial number is in the form M10-A-BCC-D-EEEE
+     * - A is the frame type, T for Trimble, the original GPS used for this modulation
+     * G for Gtop GPS
+     * - B is the year of fabrication (8 = 2018)
+     * - CC is the month of fabrication
+     * - D is the product type, 2 is production type
+     * - EEEE is the RS serial number
+     */
+    
     byte = sn_bytes[2];
     sprintf(SN, "M10-T-%1X%02u", (byte >> 4)&0xF, byte & 0xF);
     byte = sn_bytes[3] | (sn_bytes[4] << 8);
@@ -412,10 +439,10 @@ void M10TrimbleParser::printFrame() {
         timeinfo.tm_isdst = 0;
 
         frame = mktime(&timeinfo);
-		
-		// Aux data tag if the payload lenght is long
-		std::string auxstr = "";
-		if(frame_bytes[0x00] != 0x64) {
+
+        // Aux data tag if the payload lenght is long
+        std::string auxstr = "";
+        if (frame_bytes[0x00] != 0x64) {
             auxstr = "\"aux\": -1, ";
         }
 
@@ -426,7 +453,8 @@ void M10TrimbleParser::printFrame() {
                 "\"id\": \"%s\", "
                 "\"dxlid\": \"%s\", "
                 "\"datetime\": \"%04d-%02d-%02dT%02d:%02d:%02dZ\", "
-				"%s" // Aux data
+                "%s" // Aux data
+                "\"satelites\": %d, "
                 "\"lat\": %.5f, "
                 "\"lon\": %.5f, "
                 "\"alt\": %.2f, "
@@ -434,10 +462,12 @@ void M10TrimbleParser::printFrame() {
                 "\"heading\": %.5f, "
                 "\"vel_v\": %.2f, "
                 "\"temp\": %.1f, "
+                "\"battery\": %.2f, "
                 "\"crc\": %d "
                 "}\n",
-                "Trimble", frame, getSerialNumber().c_str(), getdxlSerialNumber().c_str(), getYear(), getMonth(), getDay(), getHours(), getMinutes(), getSeconds(), auxstr.c_str(), getLatitude(), getLongitude(),
-                getAltitude(), getHorizontalSpeed(), getDirection(), getVerticalSpeed(), getTemperature(), correctCRC);
+                "Trimble", frame, getSerialNumber().c_str(), getdxlSerialNumber().c_str(), getYear(), getMonth(), getDay(), getHours(), getMinutes(), getSeconds(), 
+                auxstr.c_str(), getSatellites(), getLatitude(), getLongitude(),
+                getAltitude(), getHorizontalSpeed(), getDirection(), getVerticalSpeed(), getTemperature(), getBatteryLevel(), correctCRC);
     }
 }
 

--- a/m10/M10TrimbleParser.h
+++ b/m10/M10TrimbleParser.h
@@ -28,12 +28,14 @@ public:
     virtual int getHours();
     virtual int getMinutes();
     virtual int getSeconds();
+    virtual int getSatellites();
     virtual double getVerticalSpeed();
     virtual double getHorizontalSpeed();
     virtual double getDirection();
     virtual double getTemperature();
     virtual double getHumidity();
     virtual double getDp();
+    virtual double getBatteryLevel();
     virtual std::string getSerialNumber();
     virtual std::string getdxlSerialNumber();
     


### PR DESCRIPTION
This is a PR to add the satellites number and the battery level to M10 Trimbles (or new GPS chip but same modulation), I added them as "satellites" and "battery" in the json.
I'm open for critiques for the names but I think we should uniformize theses names as they are both useful for RS hunting, the GPS number can tell us how precise the position emitted by the RS is and the battery level tells us if everything is OK and the RS will continue emit for a while.

We could send theses infos in the comments, maybe not each frame but once a while.