### PR TITLE
Update to latest dft_detect, fix log file and systemd restart issues.

### DIFF
--- a/auto_rx/auto_rx.service
+++ b/auto_rx/auto_rx.service
@@ -5,7 +5,7 @@ After=syslog.target
 [Service]
 ExecStart=/usr/bin/python /home/pi/radiosonde_auto_rx/auto_rx/auto_rx.py -t 0
 Restart=always
-RestartSec=3
+RestartSec=120
 WorkingDirectory=/home/pi/radiosonde_auto_rx/auto_rx/
 User=pi
 SyslogIdentifier=auto_rx


### PR DESCRIPTION
- systemd service restart time increased to 120 seconds (from 3 seconds)
- Don't produce a system log (log/<timestamp>_system.log) by default. --systemlog command-line flag added to re-enable it (should we add a config option for this?)
- Update to latest dft_detect - no performahce changes noted, but it does add the -c and -t options, which may be useful (-t will do away with needing to kill rtl_fm using timeout).