### PR TITLE
Use a wider FM bandwidth when scanning/decoding at 1680 MHz.

### DIFF
--- a/auto_rx/test/generate_lowsnr.py
+++ b/auto_rx/test/generate_lowsnr.py
@@ -40,7 +40,8 @@ SAMPLES = [
     ['rs41_96k_float.bin', 4800, -20.0, 96000], 
     ['rs92_96k_float.bin', 2400, -100, 96000], # No threshold set, as signal is continuous.
     ['dfm09_96k_float.bin', 2500, -100, 96000], # Weird baud rate. No threshold set, as signal is continuous.
-    ['m10_96k_float.bin', 9616, -10.0, 96000]  # Really weird baud rate.
+    ['m10_96k_float.bin', 9616, -10.0, 96000],  # Really weird baud rate.
+    #['rsngp_96k_float.bin', 2400, -100.0, 96000]  # RS92-NGP - wider bandwidth.
 ]
 
 

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -233,6 +233,37 @@ processing_type['rs92_rtlfm'] = {
 }
 
 
+# RS92-NGP (wider bandwidth)
+_fm_rate = 28000
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
+
+_demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
+
+
+processing_type['rs92ngp_rtlfm'] = {
+    'demod': _demod_command,
+    # Decode using rs92ecc
+    'decode': "../rs92ecc -vx -v --crc --ecc --vel 2>/dev/null",
+    #'decode': "../rs92ecc -vx -v --crc --ecc -r --vel 2>/dev/null", # For measuring No-ECC performance
+    # Count the number of telemetry lines.
+    "post_process" : "| grep P3213708 | wc -l",
+    #"post_process" : " | grep \"errors: 0\" | wc -l",
+    'files' : "./generated/rsngp*.bin" 
+}
+
 # DFM
 _fm_rate = 20000
 # Calculate the necessary conversions


### PR DESCRIPTION
What it says on the tin.

This is required to support RS92-NGPs (1680 MHz version of RS92). Unknown impact to other 1680 MHz sondes, though AFAIK there aren't many of these. 

The cutover frequency for changing receiver bandwidth has been set to 1 GHz.