### PR TITLE
Whitelist and Burst Timer Fixes

### DIFF
--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -533,7 +533,7 @@ def reset_all_rtlsdrs():
 
 
 
-def rtlsdr_test(device_idx='0', rtl_sdr_path="rtl_sdr"):
+def rtlsdr_test(device_idx='0', rtl_sdr_path="rtl_sdr", retries = 2):
     """ Test that a RTLSDR with supplied device ID is accessible.
 
     This function attempts to read a small set of samples from a rtlsdr using rtl-sdr.
@@ -566,7 +566,7 @@ def rtlsdr_test(device_idx='0', rtl_sdr_path="rtl_sdr"):
     # So now we know the rtlsdr we are attempting to test does exist.
     # We make an attempt to read samples from it:
 
-    _rtlsdr_retries = 2
+    _rtlsdr_retries = retries
 
     while _rtlsdr_retries > 0:
         try:

--- a/demod/rs41dm_dft.c
+++ b/demod/rs41dm_dft.c
@@ -1134,7 +1134,7 @@ int print_position(int ec) {
                 if (option_ptu && !err0 && gpx.T > -273.0) {
                     printf("{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"sats\": %d, \"bt\": %d, \"temp\":%.1f %s}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.numSV, burst_timer, gpx.T, auxbuffer);
                 } else {
-                    printf("{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"sats\": %d, \"bt\": %d, %s}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.numSV, burst_timer, auxbuffer);
+                    printf("{ \"frame\": %d, \"id\": \"%s\", \"datetime\": \"%04d-%02d-%02dT%02d:%02d:%06.3fZ\", \"lat\": %.5f, \"lon\": %.5f, \"alt\": %.5f, \"vel_h\": %.5f, \"heading\": %.5f, \"vel_v\": %.5f, \"sats\": %d, \"bt\": %d %s}\n",  gpx.frnr, gpx.id, gpx.jahr, gpx.monat, gpx.tag, gpx.std, gpx.min, gpx.sek, gpx.lat, gpx.lon, gpx.alt, gpx.vH, gpx.vD, gpx.vU, gpx.numSV, burst_timer, auxbuffer);
                 }
                 printf("\n");
             }


### PR DESCRIPTION
- Fix trailing comma bug in burst timer json output.
- Add periodic checks of the scanner RTLSDR when in whitelist mode. Interim solution until we find a better way of checking for RTLSDR locks while running the detector.