### PR TITLE
Add web server host setting to config

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -466,7 +466,7 @@ def main():
 
     # Start up the flask server.
     # This needs to occur AFTER logging is setup, else logging breaks horribly for some reason.
-    start_flask(port=config['web_port'])
+    start_flask(host=config['web_host'], port=config['web_port'])
 
     # If we have been supplied a frequency via the command line, override the whitelist settings
     # to only include the supplied frequency.
@@ -610,7 +610,7 @@ def main():
         # within a cronjob.
         if (_timeout > 0) and ((time.time()-_start_time) > _timeout):
             logging.info("Shutdown time reached. Closing.")
-            stop_flask(port=config['web_port'])
+            stop_flask(host=config['web_host'], port=config['web_port'])
             stop_all()
             break
 
@@ -623,11 +623,11 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         # Upon CTRL+C, shutdown all threads and exit.
-        stop_flask(port=config['web_port'])
+        stop_flask(host=config['web_host'], port=config['web_port'])
         stop_all()
     except Exception as e:
         # Upon exceptions, attempt to shutdown threads and exit.
         traceback.print_exc()
         print("Main Loop Error - %s" % str(e))
-        stop_flask(port=config['web_port'])
+        stop_flask(host=config['web_host'], port=config['web_port'])
         stop_all()

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -84,6 +84,7 @@ def read_auto_rx_config(filename):
 		'station_beacon_comment': "radiosonde_auto_rx SondeGate v<version>",
 		'station_beacon_icon': '/r',
 		# Web Settings,
+		'web_host'		: '0.0.0.0',
 		'web_port'		: 5000,
 		'web_archive_age': 120,
 		# Advanced Parameters
@@ -213,10 +214,12 @@ def read_auto_rx_config(filename):
 
 		# New settings added in 20180624.
 		try:
+			auto_rx_config['web_host'] = config.get('web', 'web_host')
 			auto_rx_config['web_port'] = config.getint('web', 'web_port')
 			auto_rx_config['web_archive_age'] = config.getint('web', 'archive_age')
 		except:
 			logging.error("Config - Missing Web Server settings. Using defaults.")
+			auto_rx_config['web_host'] = '0.0.0.0'
 			auto_rx_config['web_port'] = 5000
 			auto_rx_config['web_archive_age'] = 120
 

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -264,6 +264,8 @@ per_sonde_log = True
 # WEB INTERFACE SETTINNGS #
 ###########################
 [web]
+# Server Host - Can be set to :: to listen on IPv6
+web_host = 0.0.0.0
 # Server Port - Ports below 1024 can only be used if you run auto_rx as root (not recommended)
 web_port = 5000
 # Archive Age - How long to keep a sonde telemetry in memory for the web client to access, in minutes


### PR DESCRIPTION
Useful for listening on IPv6 or restricting to a particular address.

I use it set to :: to bind to all IPv6 addresses (on Linux this also listens on IPv4) and have done some limited testing of the default configuration which should still bind to all IPv4 addresses.
