### PR TITLE
Latch iMet serial numbers to avoid issues with iMet-1-RS units.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -467,7 +467,7 @@ def main():
 
     # Start up the flask server.
     # This needs to occur AFTER logging is setup, else logging breaks horribly for some reason.
-    start_flask(port=config['web_port'])
+    start_flask(host=config['web_host'], port=config['web_port'])
 
     # If we have been supplied a frequency via the command line, override the whitelist settings
     # to only include the supplied frequency.
@@ -611,7 +611,7 @@ def main():
         # within a cronjob.
         if (_timeout > 0) and ((time.time()-_start_time) > _timeout):
             logging.info("Shutdown time reached. Closing.")
-            stop_flask(port=config['web_port'])
+            stop_flask(host=config['web_host'], port=config['web_port'])
             stop_all()
             break
 
@@ -624,11 +624,11 @@ if __name__ == "__main__":
         main()
     except KeyboardInterrupt:
         # Upon CTRL+C, shutdown all threads and exit.
-        stop_flask(port=config['web_port'])
+        stop_flask(host=config['web_host'], port=config['web_port'])
         stop_all()
     except Exception as e:
         # Upon exceptions, attempt to shutdown threads and exit.
         traceback.print_exc()
         print("Main Loop Error - %s" % str(e))
-        stop_flask(port=config['web_port'])
+        stop_flask(host=config['web_host'], port=config['web_port'])
         stop_all()

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -84,6 +84,7 @@ def read_auto_rx_config(filename):
 		'station_beacon_comment': "radiosonde_auto_rx SondeGate v<version>",
 		'station_beacon_icon': '/r',
 		# Web Settings,
+		'web_host'		: '0.0.0.0',
 		'web_port'		: 5000,
 		'web_archive_age': 120,
 		# Advanced Parameters
@@ -213,10 +214,12 @@ def read_auto_rx_config(filename):
 
 		# New settings added in 20180624.
 		try:
+			auto_rx_config['web_host'] = config.get('web', 'web_host')
 			auto_rx_config['web_port'] = config.getint('web', 'web_port')
 			auto_rx_config['web_archive_age'] = config.getint('web', 'archive_age')
 		except:
 			logging.error("Config - Missing Web Server settings. Using defaults.")
+			auto_rx_config['web_host'] = '0.0.0.0'
 			auto_rx_config['web_port'] = 5000
 			auto_rx_config['web_archive_age'] = 120
 

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -264,6 +264,8 @@ per_sonde_log = True
 # WEB INTERFACE SETTINNGS #
 ###########################
 [web]
+# Server Host - Can be set to :: to listen on IPv6
+web_host = 0.0.0.0
 # Server Port - Ports below 1024 can only be used if you run auto_rx as root (not recommended)
 web_port = 5000
 # Archive Age - How long to keep a sonde telemetry in memory for the web client to access, in minutes


### PR DESCRIPTION
rs1729's comment here (https://github.com/projecthorus/radiosonde_auto_rx/issues/94#issuecomment-473624360 ) raises some scary possibilities if one of these sondes is encountered with the current iMet ID generation system.

This PR changes the logic to latch in the serial number on the first packet received, which will reduce the impact to the mapping systems. We'll still end up with multiple users generating different IDs, but at least we won't generate a new ID for every single new packet (!!).

This will unfortunately break support of multiple iMet sondes on a single frequency. I don't really see an alternative solution at this point.