### PR TITLE
Add version check on startup.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -26,7 +26,7 @@ from autorx.habitat import HabitatUploader
 from autorx.aprs import APRSUploader
 from autorx.ozimux import OziUploader
 from autorx.rotator import Rotator
-from autorx.utils import rtlsdr_test, position_info, check_rs_utils
+from autorx.utils import rtlsdr_test, position_info, check_rs_utils, check_autorx_version
 from autorx.config import read_auto_rx_config
 from autorx.web import start_flask, stop_flask, flask_emit_event, WebHandler, WebExporter
 
@@ -592,6 +592,8 @@ def main():
     exporter_functions.append(_web_exporter.add)
 
     # MQTT (?) - TODO
+
+    check_autorx_version()
 
     # Note the start time.
     _start_time = time.time()

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -12,11 +12,13 @@ import logging
 import os
 import platform
 import re
+import requests
 import subprocess
 import threading
 import time
 import numpy as np
 from math import radians, degrees, sin, cos, atan2, sqrt, pi
+from . import __version__ as auto_rx_version
 try:
     # Python 2
     from Queue import Queue
@@ -38,6 +40,32 @@ def check_rs_utils():
             return False
 
     return True
+
+
+AUTORX_VERSION_URL = "https://raw.githubusercontent.com/projecthorus/radiosonde_auto_rx/master/auto_rx/autorx/__init__.py"
+def check_autorx_version():
+    """ Grab the latest __init__ file from Github and compare the version with our current version. """
+    try:
+        _r = requests.get(AUTORX_VERSION_URL,timeout=5)
+    except Exception as e:
+        logging.error("Version - Error determining latest master version - %s" % str(e))
+        return
+
+    _version = "Unknown"
+
+    try:
+        for _line in _r.text.split('\n'):
+            if _line.startswith("__version__"):
+                _version = _line.split('=')[1]
+                _version = _version.replace("\"", "").strip()
+                break
+    except Exception as e:
+        logging.error("Version - Error determining latest master version.")
+
+    logging.info("Version - Local Version: %s  Current Master Version: %s" % (auto_rx_version, _version))
+
+
+
 
 
 class AsynchronousFileReader(threading.Thread):
@@ -714,5 +742,4 @@ def peak_decimation(freq, power, factor):
 if __name__ == "__main__":
     import sys
     logging.basicConfig(format='%(asctime)s %(levelname)s:%(message)s', level=logging.DEBUG)
-    print(lsusb())
-    print(rtlsdr_test(sys.argv[1]))
+    check_autorx_version()


### PR DESCRIPTION
Basic check of the current master version on startup. Currently not showing any warnings if it's different, just reporting the local and current master version.