### PR TITLE
Fix bug with RS41-SGM handling.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -336,7 +336,7 @@ def clean_task_list():
                 temporary_block_list[_key] = time.time()
                 # If there is a scanner currently running, add it to the scanners internal block list.
                 if 'SCAN' in autorx.task_list:
-                    auto_rx.task_list['SCAN']['task'].add_temporary_block(_key)
+                    autorx.task_list['SCAN']['task'].add_temporary_block(_key)
 
 
             # Release its associated SDR.

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.1.2-beta"
+__version__ = "1.1.3-beta"
 
 
 # Global Variables


### PR DESCRIPTION
Fix a type when handling RS41-SGM sondes which was causing auto_rx to crash out.