### PR TITLE
DFM09 Fixes, DFM APRS callsign change.

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.1.3.1"
+__version__ = "1.1.3.2"
 
 
 # Global Variables

--- a/auto_rx/autorx/aprs.py
+++ b/auto_rx/autorx/aprs.py
@@ -41,9 +41,14 @@ def telemetry_to_aprs_position(sonde_data, object_name="<id>", aprs_comment="BOM
             _object_name = sonde_data["id"].strip()
         elif sonde_data['type'] == 'DFM':
             # The DFM sonde IDs are too long to use directly.
-            # Grab the last six digits of the sonde ID (which is the serial number)
-            # TODO: Align this with whatever other decoders do.
-            _id_suffix = sonde_data['id'][-6:]
+
+            # Split out just the serial number part of the ID, and cast it to an int
+            _dfm_id = int(sonde_data['id'].split('-')[-1])
+
+            # Convert to upper-case hex, and take the last 5 nibbles.
+            _id_suffix = hex(_dfm_id).upper()[-5:]
+
+            # Append the hex ID to a shortened sonde-type.
             if "DFM09" in sonde_data['id']:
                 _object_name = "DF9" + _id_suffix
                 sonde_data['type'] = 'DFM09'

--- a/auto_rx/test/README.md
+++ b/auto_rx/test/README.md
@@ -5,9 +5,7 @@ These scripts are used to test the signal processing performance of the scripts 
 ## Dependencies
 For these scripts to work, we need:
  * The following directories created: samples, generated
- * The various demodulator binaries (rs41ecc, dft_detect, etc... ) located in ../ Currently using:
-   * dfm09ecc, m10 (from radiosonde_auto_rx), rs41ecc, rs92ecc, rs_detect, dft_detect
-   * The above can just be built using the auto_rx build.sh script.
+ * The various demodulator binaries (rs41mod, dft_detect, etc... ) located in ../  - Build these using the build.sh script.
  * CSDR installed and available on $PATH: https://github.com/simonyiszk/csdr
  * The base high-snr samples located in ./samples/. These can be downloaded from http://rfhead.net/sondes/sonde_samples.tar.gz
  * Python (2, will probably work in 3), with numpy available.
@@ -79,6 +77,7 @@ Depending on the mode, the result could be a packet count, or it could be a succ
 * dfm09_96k_float.bin - Graw DFM09, Serial Number 637797, 96 Packets
 * m10_96k_float.bin - Meteomodem M10, 120 packets
 * imet4_96k_float.bin - iMet-4, Serial Number 15236, 119 packets
+* lms6-400_96k_float.bin - Lockheed Martin LMS6 (400 MHz variant), Serial number 8097164, 120 packets.
 
 There are also a set of noise samples available [here](http://rfhead.net/sondes/noise_samples.tar.gz), which are useful for checking the detector scripts for false positives.
 

--- a/auto_rx/test/generate_lowsnr.py
+++ b/auto_rx/test/generate_lowsnr.py
@@ -42,7 +42,8 @@ SAMPLES = [
     ['dfm09_96k_float.bin', 2500, -100, 96000], # Weird baud rate. No threshold set, as signal is continuous.
     ['m10_96k_float.bin', 9616, -10.0, 96000],  # Really weird baud rate.
     ['imet4_96k_float.bin', 1200, -10.0, 96000], # 1200 baud, but AFSK, so we expect 7-8 dB worse performance than the other sondes.
-    #['rsngp_96k_float.bin', 2400, -100.0, 96000]  # RS92-NGP - wider bandwidth.
+    ['rsngp_96k_float.bin', 2400, -100.0, 96000], # RS92-NGP - wider bandwidth.
+    ['lms6-400_96k_float.bin', 4800, -100, 96000] # LMS6, 400 MHz variant. Continuous signal.
 ]
 
 

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -163,10 +163,10 @@ processing_type = {
         'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../fsk_demod --cs16 -b 1 -u 45000 --stats=100 2 96000 4800 - - 2>stats.txt | python ./bit_to_samples.py 48000 4800 | sox -t raw -r 48k -e unsigned-integer -b 8 -c 1 - -r 48000 -b 8 -t wav - 2>/dev/null|",
 
         # Decode using rs41ecc
-        'decode': "../lms6mod --vit -v 2>/dev/null",
+        'decode': "../lms6mod --json 2>/dev/null",
         # Count the number of telemetry lines.
-        "post_process" : "| wc -l",
-        'files' : "./generated/lms6-400*"
+        "post_process" : "| grep frame | wc -l",
+        'files' : "./generated/lms6-400*",
     },
 
     'lms6-1680_fsk_demod': {

--- a/demod/mod/dfm09mod.c
+++ b/demod/mod/dfm09mod.c
@@ -452,9 +452,13 @@ static int conf_out(gpx_t *gpx, ui8_t *conf_bits, int ec) {
         gpx->snc.max_ch = conf_id;
     }
 
-    if (conf_id > 4 && conf_id > gpx->snc.max_ch) gpx->snc.max_ch = conf_id; // mind. 5 Kanaele // reset? lower 0xsCaaaab?
+    if (conf_id > 4 && conf_id > gpx->snc.max_ch && ec == 0) { // mind. 5 Kanaele
+        if (bits2val(conf_bits+4, 4) == 0xC) { // 0xsCaaaab
+            gpx->snc.max_ch = conf_id; // reset?
+        }
+    }
 
-    if (conf_id > 4 && conf_id == (gpx->snc.nul_ch>>4)+1)
+    if (conf_id > 4 && (conf_id == (gpx->snc.nul_ch>>4)+1 || conf_id == gpx->snc.max_ch))
     {
         sn2_ch = bits2val(conf_bits, 8);
         sn_ch = ((sn2_ch>>4) & 0xF);


### PR DESCRIPTION
- Update to latest dfm09mod from RS repo, fixes issues with some DFM09 sondes not obtaining an ID.
- Change DFM APRS callsign format so it matches dxlAPRS.