### PR TITLE
Iterate over a copy of the dictionary (2nd instalment)

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -325,7 +325,7 @@ def handle_scan_results():
 def clean_task_list():
     """ Check the task list to see if any tasks have stopped running. If so, release the associated SDR """
 
-    for _key in autorx.task_list.keys():
+    for _key in autorx.task_list.copy().keys():
         # Attempt to get the state of the task
         try:
             _running = autorx.task_list[_key]['task'].running()
@@ -358,7 +358,7 @@ def clean_task_list():
             flask_emit_event('task_event')
 
     # Clean out the temporary block list of old entries.
-    for _freq in temporary_block_list.keys():
+    for _freq in temporary_block_list.copy().keys():
         if temporary_block_list[_freq] < (time.time() - config['temporary_block_time']*60):
             temporary_block_list.pop(_freq)
             logging.info("Task Manager - Removed %.3f MHz from temporary block list." % (_freq/1e6))

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -657,7 +657,7 @@ class SondeScanner(object):
             
             # Remove any frequencies in the temporary block list
             self.temporary_block_list_lock.acquire()
-            for _frequency in self.temporary_block_list.keys():
+            for _frequency in self.temporary_block_list.copy().keys():
                 # Check the time the block was added.
                 if self.temporary_block_list[_frequency] > (time.time()-self.temporary_block_time*60):
                     # We should still be blocking this frequency, so remove any peaks with this frequency.

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -122,7 +122,7 @@ def flask_get_telemetry_archive():
     """ Return a copy of the telemetry archive """
     # Make a copy of the store, and remove the non-serialisable GenericTrack object
     _temp_store = copy.deepcopy(flask_telemetry_store)
-    for _element in _temp_store.copy():
+    for _element in _temp_store:
         _temp_store[_element].pop('track')
 
     return json.dumps(_temp_store)

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -122,7 +122,7 @@ def flask_get_telemetry_archive():
     """ Return a copy of the telemetry archive """
     # Make a copy of the store, and remove the non-serialisable GenericTrack object
     _temp_store = copy.deepcopy(flask_telemetry_store)
-    for _element in _temp_store:
+    for _element in _temp_store.copy():
         _temp_store[_element].pop('track')
 
     return json.dumps(_temp_store)


### PR DESCRIPTION
Followup to https://github.com/projecthorus/radiosonde_auto_rx/pull/210, with the aim of proactively dealing with other occurances where a `pop` will cause a dictionary to be modified while being iterated over.

As far as I know I hadn't experienced any issues with any of these yet, but it may just be I haven't exercised the relevant code-paths in my simple usage so far. With that in mind, these changes should be assumed to be untested.