### PR TITLE
Decoder rebase, few other fixes.

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.1.4-beta4"
+__version__ = "1.2.0-beta1"
 
 
 # Global Variables

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.2.0-beta1"
+__version__ = "1.2.0-beta2"
 
 
 # Global Variables

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -66,7 +66,8 @@ def read_auto_rx_config(filename, no_sdr_test=False):
 		'station_lat'	: 0.0,
 		'station_lon'	: 0.0,
 		'station_alt'	: 0.0,
-		'station_code'	: 'SONDE',
+		'station_code'	: 'SONDE',	# NOTE: This will not be read from the config file, but will be left in place for now
+									# as a default setting.
 		'gpsd_enabled'	: False,
 		'gpsd_host'		: 'localhost',
 		'gpsd_port'		: 2947,
@@ -254,10 +255,11 @@ def read_auto_rx_config(filename, no_sdr_test=False):
 		auto_rx_config['save_decode_audio'] = config.getboolean('debugging', 'save_decode_audio')
 		auto_rx_config['save_decode_iq'] = config.getboolean('debugging', 'save_decode_iq')
 
-		auto_rx_config['station_code'] = config.get('location', 'station_code')
-		if len(auto_rx_config['station_code']) > 5:
-			auto_rx_config['station_code'] = auto_rx_config['station_code'][:5]
-			logging.warning("Config - Clipped station code to 5 digits: %s" % auto_rx_config['station_code'])
+		# NOTE 2019-09-21: The station code will now be fixed at the default to avoid multiple iMet callsign issues.
+		# auto_rx_config['station_code'] = config.get('location', 'station_code')
+		# if len(auto_rx_config['station_code']) > 5:
+		# 	auto_rx_config['station_code'] = auto_rx_config['station_code'][:5]
+		# 	logging.warning("Config - Clipped station code to 5 digits: %s" % auto_rx_config['station_code'])
 
 		auto_rx_config['temporary_block_time'] = config.getint('advanced', 'temporary_block_time')
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -93,7 +93,7 @@ class SondeDecoder(object):
         experimental_decoder = False,
         decoder_stats = False,
 
-        imet_location = ""):
+        imet_location = "SONDE"):
         """ Initialise and start a Sonde Decoder.
 
         Args:

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -637,7 +637,6 @@ class SondeDecoder(object):
         while (not asyncreader.eof()) and self.decoder_running:
             for _line in asyncreader.readlines():
                 self.demod_stats.update(_line)
-            
             # Avoid spinlocking..
             # Probably about time we looked at using async for this stuff...
             time.sleep(0.2)

--- a/auto_rx/autorx/fsk_demod.py
+++ b/auto_rx/autorx/fsk_demod.py
@@ -69,18 +69,18 @@ class FSKDemodStats(object):
         if type(data) == bytes:
             data = data.decode('ascii')
 
-        if type(data) == str:
+        if type(data) == dict:
+            _data = data
+        
+        else:
             # Attempt to parse string.
             try:
                 _data = json.loads(data)
             except Exception as e:
-                self.log_error("FSK Demod Stats - %s" % str(e))
+                # Be quiet for now...
+                #self.log_error("FSK Demod Stats - %s" % str(e))
                 return
-        elif type(data) == dict:
-            _data = data
         
-        else:
-            return
 
         # Check for required fields in incoming dictionary.
         for _field in self.FSK_STATS_FIELDS:

--- a/auto_rx/autorx/habitat.py
+++ b/auto_rx/autorx/habitat.py
@@ -90,11 +90,12 @@ def sonde_telemetry_to_sentence(telemetry, payload_callsign=None, comment=None):
         if (telemetry['bt'] != -1) and (telemetry['bt'] != 65535):
             _sentence += " BT %s" % time.strftime("%H:%M:%S", time.gmtime(telemetry['bt']))
 
+    # NOTE: Disabled as of 2019-09-21
     # Add on the station code, which will only be present if we are receiving an iMet sonde.
     # This may assist multiple receiving stations in the vicinity of an iMet launch site coordinate
     # the iMet unique ID generation.
-    if 'station_code' in telemetry:
-        _sentence += " LOC: %s" % telemetry['station_code']
+    #if 'station_code' in telemetry:
+    #    _sentence += " LOC: %s" % telemetry['station_code']
 
     # Add on any custom comment data if provided.
     if comment != None:

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -10,11 +10,11 @@ echo "Building dft_detect"
 cd ../scan/
 gcc dft_detect.c -lm -o dft_detect -DNOC34C50
 
-echo "Building RS92/RS41/DFM Demodulators"
-cd ../demod/
-gcc -c demod.c
-gcc -c demod_dft.c
-gcc dfm09dm_dft.c demod_dft.o -lm -o dfm09ecc
+echo "Building RS92/RS41/DFM/LMS6/iMS Demodulators"
+#cd ../demod/
+#gcc -c demod.c
+#gcc -c demod_dft.c
+#gcc dfm09dm_dft.c demod_dft.o -lm -o dfm09ecc
 
 # New demodulators
 cd ../demod/mod/

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -92,15 +92,6 @@ station_lat = 0.0
 station_lon = 0.0
 station_alt = 0.0
 
-# Location Code (Maximum 5 characters)
-# This is ONLY used by the Intermet iMet decoder, to provide additional entropy when
-# generating a unique ID for the iMet sondes, which do not transmit their serial number. 
-# If you know the WMO number of the launch site, then this would be a good value to use. 
-# Otherwise the ICAO Code of the airport nearest to the launch site would also work.
-# If you are not expecting to RX iMet sondes, then this can be left at its default.
-# NOTE: Only change this if you are 100% sure you will only be receiving sondes from a single launch location!
-station_code = SONDE
-
 # Station Position from GPSD
 # If your station is likely to move, then you may wish to have your station position updated from GPSD.
 # NOTE: This feature is intended to make life slightly easier when using an auto_rx station in a portable

--- a/auto_rx/test/bit_to_samples.py
+++ b/auto_rx/test/bit_to_samples.py
@@ -1,22 +1,40 @@
 #!/usr/bin/env python
+#
+#	Convert one-byte-per-bit representation (i.e. from fsk_demod) to a pseudo-FM-demod representation.
+#
 import sys
+
+# Check if we are running in Python 2 or 3
+PY3 = sys.version_info[0] == 3
 
 _sample_rate = int(sys.argv[1])
 _symbol_rate = int(sys.argv[2])
 
 _bit_length = _sample_rate // _symbol_rate
 
-_zero = '\x00'*_bit_length
-_one = '\xFF'*_bit_length
+if PY3:
+	_zero = b'\x00'*_bit_length
+	_one = b'\xFF'*_bit_length
+
+	_in = sys.stdin.read
+	_out = sys.stdout.buffer.write
+
+else:
+	_zero = '\x00'*_bit_length
+	_one = '\xFF'*_bit_length
+
+	_in = sys.stdin.read
+	_out = sys.stdout.write	
 
 while True:
-	_char = sys.stdin.read(1)
-	if _char == '':
+	_char = _in(1)
+
+	if _char == '' or _char == b'':
 		sys.exit(0)
 
 	if _char == '\x00':
-		sys.stdout.write(_zero)
+		_out(_zero)
 	else:
-		sys.stdout.write(_one)
+		_out(_one)
 
 	sys.stdout.flush()

--- a/auto_rx/utils/plot_sonde_log.py
+++ b/auto_rx/utils/plot_sonde_log.py
@@ -173,6 +173,7 @@ def read_log_file(filename, decimation=10, min_altitude=100):
     altitude = []
     temperature = []
     humidity = []
+    snr = []
 
     with open(filename, 'r') as _file:
         for line in _file:
@@ -187,6 +188,11 @@ def read_log_file(filename, decimation=10, min_altitude=100):
                 _temp = float(_fields[6])
                 _hum = float(_fields[7])
 
+                if 'SNR' in _fields[10]:
+                    _snr = float(_fields[10].split(' ')[1])
+                else:
+                    _snr = -1.0
+
                 # Append data to arrays.
                 times.append(_time)
                 latitude.append(_lat)
@@ -194,6 +200,7 @@ def read_log_file(filename, decimation=10, min_altitude=100):
                 altitude.append(_alt)
                 temperature.append(_temp)
                 humidity.append(_hum)
+                snr.append(_snr)
             except Exception as e:
                 print("Error reading line: ")
 
@@ -201,7 +208,7 @@ def read_log_file(filename, decimation=10, min_altitude=100):
 
     _output = [] # Altitude, Wind Speed, Wind Direction, Temperature, Dew Point
     # First entry, We assume all the values are unknown for now.
-    _output.append([altitude[0], np.NaN, np.NaN, np.NaN, np.NaN, np.NaN])
+    _output.append([altitude[0], np.NaN, np.NaN, np.NaN, np.NaN, np.NaN, snr[0]])
 
     _burst = False
     _startalt = altitude[0]
@@ -239,7 +246,7 @@ def read_log_file(filename, decimation=10, min_altitude=100):
         _heading = _movement['bearing']
         _velocity = _movement['great_circle_distance']/_delta_seconds
 
-        _output.append([altitude[i], _velocity, _heading, T, DP, RH])
+        _output.append([altitude[i], _velocity, _heading, T, DP, RH, snr[i]])
 
         i += decimation
 
@@ -423,10 +430,6 @@ def process_directory(log_dir, output_dir, status_file, time_limit = 60):
 
     # Write out the status file
     write_status_file(status_file, _log_status)
-
-
-
-
 
 
 if __name__ == "__main__":

--- a/demod/mod/demod_mod.h
+++ b/demod/mod/demod_mod.h
@@ -92,6 +92,7 @@ typedef struct {
     double V_signal;
     double SNRdB;
 
+    // decimate
     int decM;
     ui32_t sr_base;
     ui32_t dectaps;
@@ -101,6 +102,13 @@ typedef struct {
     float complex *decMbuf;
     float complex *ex; // exp_lut
     double xlt_fq;
+
+    // IF: lowpass
+    int opt_lp;
+    int lpIQ_bw;
+    int lpIQtaps; // ui32_t
+    float *ws_lpIQ;
+    float complex *lpIQ_buf;
 
 } dsp_t;
 

--- a/demod/mod/dfm09mod.c
+++ b/demod/mod/dfm09mod.c
@@ -452,7 +452,7 @@ static int conf_out(gpx_t *gpx, ui8_t *conf_bits, int ec) {
         gpx->snc.max_ch = conf_id;
     }
 
-    if (conf_id > 4 && conf_id > gpx->snc.max_ch && ec == 0) { // mind. 5 Kanaele
+    if (conf_id > 5 && conf_id > gpx->snc.max_ch && ec == 0) { // mind. 6 Kanaele
         if (bits2val(conf_bits+4, 4) == 0xC) { // 0xsCaaaab
             gpx->snc.max_ch = conf_id; // reset?
         }
@@ -836,6 +836,7 @@ int main(int argc, char **argv) {
     int option_dist = 0;     // continuous pcks 0..8
     int option_auto = 0;
     int option_iq = 0;
+    int option_lp = 0;
     int option_bin = 0;
     int option_json = 0;     // JSON blob output (for auto_rx)
     int wavloaded = 0;
@@ -940,6 +941,17 @@ int main(int argc, char **argv) {
         else if   (strcmp(*argv, "--iq0") == 0) { option_iq = 1; }  // differential/FM-demod
         else if   (strcmp(*argv, "--iq2") == 0) { option_iq = 2; }
         else if   (strcmp(*argv, "--iq3") == 0) { option_iq = 3; }  // iq2==iq3
+        else if   (strcmp(*argv, "--IQ") == 0) { // fq baseband -> IF (rotate from and decimate)
+            double fq = 0.0;                     // --IQ <fq> , -0.5 < fq < 0.5
+            ++argv;
+            if (*argv) fq = atof(*argv);
+            else return -1;
+            if (fq < -0.5) fq = -0.5;
+            if (fq >  0.5) fq =  0.5;
+            dsp.xlt_fq = -fq; // S(t) -> S(t)*exp(-f*2pi*I*t)
+            option_iq = 5;
+        }
+        else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
         else if   (strcmp(*argv, "--dbg") == 0) { gpx.option.dbg = 1; }
         else {
             fp = fopen(*argv, "rb");
@@ -1000,7 +1012,9 @@ int main(int argc, char **argv) {
         dsp.hdrlen = strlen(dfm_rawheader);
         dsp.BT = 0.5; // bw/time (ISI) // 0.3..0.5
         dsp.h = 1.8;  // 2.4 modulation index abzgl. BT
+        dsp.lpIQ_bw = 12e3;
         dsp.opt_iq = option_iq;
+        dsp.opt_lp = option_lp;
 
         if ( dsp.sps < 8 ) {
             fprintf(stderr, "note: sample rate low\n");

--- a/demod/mod/lms6Xmod.c
+++ b/demod/mod/lms6Xmod.c
@@ -146,6 +146,7 @@ typedef struct {
     int typ;
     float frm_rate;
     int auto_detect;
+    int reset_dsp;
     option_t option;
     RS_t RS;
     VIT_t *vit;
@@ -840,7 +841,7 @@ static void proc_frame(gpx_t *gpx, int len) {
                 if (gpx->sf6 < 4) {
                     frmsync_X(gpx, block_bytes); // pos(frm_syncX[]) < 46: different baud not significant
                     if (gpx->sfX == 4)  {
-                        if (gpx->auto_detect) gpx->typ = 10;
+                        if (gpx->auto_detect) { gpx->typ = 10; gpx->reset_dsp = 1; }
                         break;
                     }
                 }
@@ -881,7 +882,7 @@ static void proc_frame(gpx_t *gpx, int len) {
                 for (j = 0; j < 4; j++) gpx->sf6 += (block_bytes[blk_pos+j] == frm_sync6[j]);
                 if (gpx->sf6 == 4)  {
                     gpx->frm_pos = 0;
-                    if (gpx->auto_detect) gpx->typ = 6;
+                    if (gpx->auto_detect) { gpx->typ = 6; gpx->reset_dsp = 1; }
                     break;
                 }
                 blk_pos++;
@@ -891,7 +892,7 @@ static void proc_frame(gpx_t *gpx, int len) {
             // LMS6: frm_rate = 4800.0 * FRAME_LEN/BLOCK_LEN = 4800*300/260 = 5538
             // LMSX: delta_mp = 4797.8 (longer timesync-frames possible)
             if (gpx->frm_rate > 5000.0 || gpx->frm_rate < 4000.0) { // lms6-blocklen = 260/300 sr, sync wird ueberlesen ...
-                if (gpx->auto_detect) gpx->typ = 6;
+                if (gpx->auto_detect) { gpx->typ = 6; gpx->reset_dsp = 1; }
             }
         }
         else
@@ -923,6 +924,7 @@ int main(int argc, char **argv) {
 
     int option_inv = 0;    // invertiert Signal
     int option_iq = 0;
+    int option_lp = 0;
     int option_dc = 0;
     int wavloaded = 0;
     int sel_wavch = 0;     // audio channel: left
@@ -968,7 +970,7 @@ int main(int argc, char **argv) {
     gpx_t _gpx = {0}; gpx_t *gpx = &_gpx;
 
     gpx->auto_detect = 1;
-
+    gpx->reset_dsp = 0;
 
 #ifdef CYGWIN
     _setmode(fileno(stdin), _O_BINARY);  // _setmode(_fileno(stdin), _O_BINARY);
@@ -1015,9 +1017,6 @@ int main(int argc, char **argv) {
         else if ( (strcmp(*argv, "-i") == 0) || (strcmp(*argv, "--invert") == 0) ) {
             option_inv = 1;  // nicht noetig
         }
-        else if ( (strcmp(*argv, "--dc") == 0) ) {
-            option_dc = 1;
-        }
         else if ( (strcmp(*argv, "--ch2") == 0) ) { sel_wavch = 1; }  // right channel (default: 0=left)
         else if ( (strcmp(*argv, "--ths") == 0) ) {
             ++argv;
@@ -1048,6 +1047,8 @@ int main(int argc, char **argv) {
             dsp.xlt_fq = -fq; // S(t) -> S(t)*exp(-f*2pi*I*t)
             option_iq = 5;
         }
+        else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
+        else if   (strcmp(*argv, "--dc") == 0) { option_dc = 1; }
         else if   (strcmp(*argv, "--json") == 0) {
             gpx->option.jsn = 1;
             gpx->option.ecc = 1;
@@ -1108,7 +1109,9 @@ int main(int argc, char **argv) {
     dsp.hdrlen = strlen(rawheader);
     dsp.BT = 1.2; // bw/time (ISI) // 1.0..2.0  // BT(lmsX) < BT(lms6) ? -> init_buffers()
     dsp.h = 0.9;  // 0.95 modulation index
+    dsp.lpIQ_bw = 8e3;
     dsp.opt_iq = option_iq;
+    dsp.opt_lp = option_lp;
 
     if ( dsp.sps < 8 ) {
         fprintf(stderr, "note: sample rate low (%.1f sps)\n", dsp.sps);
@@ -1205,12 +1208,18 @@ int main(int argc, char **argv) {
             pos = BLOCKSTART;
             header_found = 0;
 
-            if ( gpx->auto_detect ) {
+            if ( gpx->auto_detect && gpx->reset_dsp ) {
                 if (gpx->typ == 10) {
                     // set lmsX
                     rawbitblock_len = RAWBITBLOCK_LEN;//_X;
                     dsp.br = (float)BAUD_RATEX;
                     dsp.sps = (float)dsp.sr/dsp.br;
+
+                    // reset F1sum, F2sum
+                    for (k = 0; k < dsp.N_IQBUF; k++) dsp.rot_iqbuf[k] = 0;
+                    dsp.F1sum = 0;
+                    dsp.F2sum = 0;
+
                     bitofs = bitofsX + shift;
                 }
                 if (gpx->typ == 6) {
@@ -1218,8 +1227,15 @@ int main(int argc, char **argv) {
                     rawbitblock_len = RAWBITBLOCK_LEN_6;
                     dsp.br = (float)BAUD_RATE6;
                     dsp.sps = (float)dsp.sr/dsp.br;
+
+                    // reset F1sum, F2sum
+                    for (k = 0; k < dsp.N_IQBUF; k++) dsp.rot_iqbuf[k] = 0;
+                    dsp.F1sum = 0;
+                    dsp.F2sum = 0;
+
                     bitofs = bitofs6 + shift;
                 }
+                gpx->reset_dsp = 0;
             }
 
         }

--- a/demod/mod/meisei100mod.c
+++ b/demod/mod/meisei100mod.c
@@ -210,6 +210,7 @@ int main(int argc, char **argv) {
         option_jsn = 0;    // JSON output (auto_rx)
     int wavloaded = 0;
     int option_iq = 0;
+    int option_lp = 0;
     int option_dc = 0;
     int sel_wavch = 0;
 
@@ -334,6 +335,7 @@ int main(int argc, char **argv) {
             dsp.xlt_fq = -fq; // S(t) -> S(t)*exp(-f*2pi*I*t)
             option_iq = 5;
         }
+        else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
 //        else if ( (strcmp(*argv, "--dc") == 0) ) { option_dc = 1; }
         else if   (strcmp(*argv, "--json") == 0) {
             option_jsn = 1;
@@ -380,7 +382,9 @@ int main(int argc, char **argv) {
     dsp.hdrlen = strlen(rawheader);
     dsp.BT = 1.2; // bw/time (ISI) // 1.0..2.0
     dsp.h = 2.4;  // 2.8
+    dsp.lpIQ_bw = 16e3;
     dsp.opt_iq = option_iq;
+    dsp.opt_lp = option_lp;
 
     if ( dsp.sps < 8 ) {
         fprintf(stderr, "note: sample rate low (%.1f sps)\n", dsp.sps);

--- a/m10/M10TrimbleParser.cpp
+++ b/m10/M10TrimbleParser.cpp
@@ -336,12 +336,14 @@ std::string M10TrimbleParser::getSerialNumber() {
      * - CC is the month of fabrication
      * - D is the product type, 2 is production type
      * - EEEE is the RS serial number
+
+     NOTE: Removed -T from callsign. 2019-09-21
      */
     
     byte = sn_bytes[2];
-    sprintf(SN, "M10-T-%1X%02u", (byte >> 4)&0xF, byte & 0xF);
+    sprintf(SN, "M10-%1X%02u", (byte >> 4)&0xF, byte & 0xF);
     byte = sn_bytes[3] | (sn_bytes[4] << 8);
-    sprintf(SN + 9, "-%1X-%1u%04u", sn_bytes[0]&0xF, (byte >> 13)&0x7, byte & 0x1FFF);
+    sprintf(SN + 7, "-%1X-%1u%04u", sn_bytes[0]&0xF, (byte >> 13)&0x7, byte & 0x1FFF);
 
     return SN;
 }


### PR DESCRIPTION
- Remove station_code from config file. Just use the default of SONDE.
- Fix bit_to_samples operation under Python 3.7 (it was broken, but in a 'silent' way, which means the experimental demod would not work correctly under Python 3)
- Remove -T (Trimble vs GTop) part from M10 serial number.
- Update all decoders to latest upstream version.