### PR TITLE
Decoder Rebase, Switch to m10mod, dft_detect IQ input

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.2.0-beta4"
+__version__ = "1.2.0-beta5"
 
 
 # Global Variables

--- a/auto_rx/autorx/aprs.py
+++ b/auto_rx/autorx/aprs.py
@@ -70,7 +70,7 @@ def telemetry_to_aprs_position(sonde_data, object_name="<id>", aprs_comment="BOM
 
         elif 'M10' in sonde_data['type']:
             # Use the generated id same as dxlAPRS
-            _object_name = sonde_data['dxlid']
+            _object_name = sonde_data['aprsid']
 
         elif 'iMet' in sonde_data['type']:
             # Use the last 5 characters of the unique ID we have generated.

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -345,7 +345,7 @@ class SondeDecoder(object):
                 decode_cmd += " tee decode_%s.wav |" % str(self.device_idx)
 
             # M10 decoder
-            decode_cmd += "./m10 -b -b2 2>/dev/null"
+            decode_cmd += "./m10mod --json -vvv 2>/dev/null"
 
         elif self.sonde_type == "iMet":
             # iMet-4 Sondes
@@ -559,7 +559,7 @@ class SondeDecoder(object):
             decode_cmd += "./dfm09mod -vv --ecc --json --dist --auto --bin 2>/dev/null"
 
             # DFM sondes transmit continuously - average over the last 2 frames, and use a mean
-            demod_stats = FSKDemodStats(averaging_time=2.0, peak_hold=False)
+            demod_stats = FSKDemodStats(averaging_time=1.0, peak_hold=False)
             self.rx_frequency = _freq
 
         elif self.sonde_type == "M10":
@@ -588,7 +588,7 @@ class SondeDecoder(object):
                 decode_cmd += " tee decode_%s.wav |" % str(self.device_idx)
 
             # M10 decoder
-            decode_cmd += "./m10 -b -b2 2>/dev/null"
+            decode_cmd += "./m10mod --json -vvv 2>/dev/null"
 
             # M10 sondes transmit in short, irregular pulses - average over the last 2 frames, and use a peak hold
             demod_stats = FSKDemodStats(averaging_time=2.0, peak_hold=True)

--- a/auto_rx/autorx/habitat.py
+++ b/auto_rx/autorx/habitat.py
@@ -82,8 +82,21 @@ def sonde_telemetry_to_sentence(telemetry, payload_callsign=None, comment=None):
         telemetry['temp'],
         telemetry['humidity'])
 
+    if 'f_centre' in telemetry:
+        # We have an estimate of the sonde's centre frequency from the modem, use this in place of
+        # the RX frequency.
+        # Round to 1 kHz
+        _freq = round(telemetry['f_centre']/1000.0)
+        # Convert to MHz.
+        _freq = "%.3f MHz" % (_freq/1e3)
+    else:
+        # Otherwise, use the normal frequency.
+        _freq = telemetry['freq']
+
+
+
     # Add in a comment field, containing the sonde type, serial number, and frequency.
-    _sentence += ",%s %s %s" % (telemetry['type'], telemetry['id'], telemetry['freq'])
+    _sentence += ",%s %s %s" % (telemetry['type'], telemetry['id'], _freq)
 
     # Check for Burst/Kill timer data, and add in.
     if 'bt' in telemetry:

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -202,6 +202,11 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
 
     """
 
+    # Notes:
+    # 400 MHz sondes: Use --bw 20  (20 kHz BW)
+    # 1680 MHz RS92 Setting: --bw 32
+    # 1680 MHz LMS6-1680: Use FM demod. as usual.
+
     # Example command (for command-line testing):
     # rtl_fm -T -p 0 -M fm -g 26.0 -s 15k -f 401500000 | sox -t raw -r 15k -e s -b 16 -c 1 - -r 48000 -t wav - highpass 20 | ./rs_detect -z -t 8
 
@@ -217,7 +222,9 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
     # Adjust the detection bandwidth based on the band the scanning is occuring in.
     if frequency < 1000e6:
         # 400-406 MHz sondes - use a 22 kHz detection bandwidth.
-        _rx_bw = 22000
+        _mode = 'IQ'
+        _iq_bw = 48000
+        _if_bw = 20
     else:
         # 1680 MHz sondes
         # Both the RS92-NGP and 1680 MHz LMS6 have a much wider bandwidth than their 400 MHz counterparts.
@@ -225,22 +232,42 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
         # Given the huge difference between these two, we default to using a very wide FM bandwidth, but allow the user
         # to narrow this if only RS92-NGPs are expected.
         if ngp_tweak:
-            _rx_bw = 30000
+            # RS92-NGP detection
+            _mode = 'IQ'
+            _iq_bw = 48000
+            _if_bw = 32
         else:
+            # LMS6-1680 Detection
+            _mode = 'FM'
             _rx_bw = 200000
 
-    # Sample Source (rtl_fm)
-    rx_test_command = "timeout %ds %s %s-p %d -d %s %s-M fm -F9 -s %d -f %d 2>/dev/null |" % (dwell_time*2, sdr_fm, bias_option, int(ppm), str(device_idx), gain_param, _rx_bw, frequency) 
-    # Sample filtering
-    rx_test_command += "sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null | " % _rx_bw
 
-    # Saving of Debug audio, if enabled,
-    if save_detection_audio:
-        rx_test_command += "tee detect_%s.wav | " % str(device_idx)
+    if _mode == 'IQ':
+        # IQ decoding
+        # Sample source (rtl_fm, in IQ mode)
+        rx_test_command = "timeout %ds %s %s-p %d -d %s %s-M raw -F9 -s %d -f %d 2>/dev/null |" % (dwell_time*2, sdr_fm, bias_option, int(ppm), str(device_idx), gain_param, _iq_bw, frequency)
+        # Saving of Debug audio, if enabled,
+        if save_detection_audio:
+            rx_test_command += "tee detect_%s.raw | " % str(device_idx)
 
-    # Sample decoding / detection
-    # Note that we detect for dwell_time seconds, and timeout after dwell_time*2, to catch if no samples are being passed through.
-    rx_test_command += os.path.join(rs_path,"dft_detect") + " -t %d 2>/dev/null" % dwell_time
+        rx_test_command += os.path.join(rs_path,"dft_detect") + " -t %d --iq --bw %d --dc - %d 16 2>/dev/null" % (dwell_time, _if_bw, _iq_bw)
+   
+    elif _mode == 'FM':
+        # FM decoding
+
+        # Sample Source (rtl_fm)
+        rx_test_command = "timeout %ds %s %s-p %d -d %s %s-M fm -F9 -s %d -f %d 2>/dev/null |" % (dwell_time*2, sdr_fm, bias_option, int(ppm), str(device_idx), gain_param, _rx_bw, frequency) 
+        # Sample filtering
+        rx_test_command += "sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -t wav - highpass 20 2>/dev/null | " % _rx_bw
+
+        # Saving of Debug audio, if enabled,
+        if save_detection_audio:
+            rx_test_command += "tee detect_%s.wav | " % str(device_idx)
+
+        # Sample decoding / detection
+        # Note that we detect for dwell_time seconds, and timeout after dwell_time*2, to catch if no samples are being passed through.
+        rx_test_command += os.path.join(rs_path,"dft_detect") + " -t %d 2>/dev/null" % dwell_time
+
 
     logging.debug("Scanner #%s - Using detection command: %s" % (str(device_idx), rx_test_command))
     logging.debug("Scanner #%s - Attempting sonde detection on %.3f MHz" % (str(device_idx), frequency/1e6))
@@ -263,11 +290,11 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
         else:
             _runtime = time.time() - _start
             logging.debug("Scanner #%s - dft_detect exited in %.1f seconds with return code %d." % (str(device_idx), _runtime, e.returncode))
-            return None
+            return (None, 0.0)
     except Exception as e:
         # Something broke when running the detection function.
         logging.error("Scanner #%s - Error when running dft_detect - %s" % (str(device_idx), str(e)))
-        return None
+        return (None, 0.0)
 
 
     _runtime = time.time() - _start
@@ -276,7 +303,7 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
     # Check for no output from dft_detect.
     if ret_output is None or ret_output == "":
         #logging.error("Scanner - dft_detect returned no output?")
-        return None
+        return (None, 0.0)
 
 
 
@@ -286,51 +313,67 @@ def detect_sonde(frequency, rs_path="./", dwell_time=10, sdr_fm='rtl_fm', device
 
     if len(_fields) <2:
         logging.error("Scanner - malformed output from dft_detect: %s" % ret_output.strip())
-        return None
+        return (None, 0.0)
 
     _type = _fields[0]
-    _score = float(_fields[1].strip())
+    _score = _fields[1]
 
+    # Detect any frequency correction information:
+    try:
+        if ',' in _score:
+            _offset_est = float(_score.split(',')[1].split('Hz')[0].strip())
+            _score = float(_score.split(',')[0].strip())
+        else:
+            _score = float(_score.strip())
+            _offset_est = 0.0
+    except Exception as e:
+        logging.error("Scanner - Error parsing dft_detect output: %s" % ret_output.strip())
+        return (None, 0.0)
+
+
+    _sonde_type = None
 
     if 'RS41' in _type:
-        logging.debug("Scanner #%s - Detected a RS41! (Score: %.2f)" % (str(device_idx), _score))
-        return "RS41"
+        logging.debug("Scanner #%s - Detected a RS41! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
+        _sonde_type = "RS41"
     elif 'RS92' in _type:
-        logging.debug("Scanner #%s - Detected a RS92! (Score: %.2f)" % (str(device_idx), _score))
-        return "RS92"
+        logging.debug("Scanner #%s - Detected a RS92! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
+        _sonde_type = "RS92"
     elif 'DFM' in _type:
-        logging.debug("Scanner #%s - Detected a DFM Sonde! (Score: %.2f)" % (str(device_idx), _score))
-        return "DFM"
+        logging.debug("Scanner #%s - Detected a DFM Sonde! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
+        _sonde_type = "DFM"
     elif 'M10' in _type:
-        logging.debug("Scanner #%s - Detected a M10 Sonde! (Score: %.2f)" % (str(device_idx), _score))
-        return "M10"
-    elif 'IMET1RS' in _type:
-        logging.debug("Scanner #%s - Detected a iMet-4 Sonde! (Score: %.2f)" % (str(device_idx), _score))
-        return "iMet"     
-    elif 'IMET' in _type:
+        logging.debug("Scanner #%s - Detected a M10 Sonde! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
+        _sonde_type = "M10"
+    elif 'IMET4' in _type:
+        logging.debug("Scanner #%s - Detected a iMet-4 Sonde! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))  
+        _sonde_type = "iMet"
+    elif 'IMET1' in _type:
         logging.debug("Scanner #%s - Detected a iMet Sonde! (Type %s - Unsupported) (Score: %.2f)" % (str(device_idx), _type, _score))
-        return _type
+        _sonde_type = "IMET1"
     elif 'LMS6' in _type:
-        logging.debug("Scanner #%s - Detected a LMS6 Sonde! (Score: %.2f)" % (str(device_idx), _score))
-        return 'LMS6'
+        logging.debug("Scanner #%s - Detected a LMS6 Sonde! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
+        _sonde_type = "LMS6"
     elif 'C34' in _type:
         logging.debug("Scanner #%s - Detected a Meteolabor C34/C50 Sonde! (Unsupported) (Score: %.2f)" % (str(device_idx), _score))
-        return 'C34C50'
+        _sonde_type = "C34C50"
     elif 'MK2LMS' in _type:
-        logging.debug("Scanner #%s - Detected a 1680 MHz LMS6 Sonde (MK2A Telemetry)! (Score: %.2f)" % (str(device_idx), _score))
+        logging.debug("Scanner #%s - Detected a 1680 MHz LMS6 Sonde (MK2A Telemetry)! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
         if _score < 0:
-            return '-MK2LMS'
+            _sonde_type = '-MK2LMS'
         else:
-            return 'MK2LMS'
+            _sonde_type = 'MK2LMS'
     elif 'MEISEI' in _type:
-        logging.debug("Scanner #%s - Detected a Meisei Sonde! (Score: %.2f)" % (str(device_idx), _score))
+        logging.debug("Scanner #%s - Detected a Meisei Sonde! (Score: %.2f, Offset: %.1f Hz)" % (str(device_idx), _score, _offset_est))
         # Not currently sure if we expect to see inverted Meisei sondes.
         if _score < 0:
-            return '-MEISEI'
+            _sonde_type = '-MEISEI'
         else:
-            return 'MEISEI'
+            _sonde_type = 'MEISEI'
     else:
-        return None
+        _sonde_type = None
+
+    return (_sonde_type, _offset_est)
 
 
 
@@ -718,7 +761,7 @@ class SondeScanner(object):
             if self.sonde_scanner_running == False:
                 return []
 
-            detected = detect_sonde(_freq,
+            (detected, offset_est) = detect_sonde(_freq,
                 sdr_fm=self.sdr_fm,
                 device_idx=self.device_idx,
                 ppm=self.ppm,
@@ -728,6 +771,10 @@ class SondeScanner(object):
                 save_detection_audio=self.save_detection_audio)
 
             if detected != None:
+                # Quantize the detected frequency (with offset) to 1 kHz
+                _freq = round((_freq + offset_est)/1000.0)*1000.0
+
+
                 # Add a detected sonde to the output array
                 _search_results.append([_freq, detected])
 

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -30,7 +30,7 @@ except ImportError:
 
 
 # List of binaries we check for on startup
-REQUIRED_RS_UTILS = ['dft_detect', 'dfm09mod', 'm10', 'imet1rs_dft', 'rs41mod', 'rs92mod', 'fsk_demod', 'mk2a_lms1680', 'lms6Xmod', 'meisei100mod']
+REQUIRED_RS_UTILS = ['dft_detect', 'dfm09mod', 'm10mod', 'imet1rs_dft', 'rs41mod', 'rs92mod', 'fsk_demod', 'mk2a_lms1680', 'lms6Xmod', 'meisei100mod']
 
 def check_rs_utils():
     """ Check the required RS decoder binaries exist

--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -26,7 +26,7 @@ gcc rs92mod.c demod_mod.o bch_ecc_mod.o -lm -o rs92mod -w
 gcc lms6mod.c demod_mod.o bch_ecc_mod.o -lm -o lms6mod -w
 gcc lms6Xmod.c demod_mod.o bch_ecc_mod.o -lm -o lms6Xmod -w
 gcc meisei100mod.c demod_mod.o bch_ecc_mod.o -lm -o meisei100mod -w
-#gcc m10mod.c demod_mod.o -lm -o m10mod -w
+gcc m10mod.c demod_mod.o -lm -o m10mod -w
 
 # Build LMS6-1680 Decoder
 echo "Building LMS6-1680 Demodulator."
@@ -34,9 +34,9 @@ cd ../../mk2a/
 gcc mk2a_lms1680.c -lm -o mk2a_lms1680
 
 # Build M10 decoder
-echo "Building M10 Demodulator."
-cd ../m10/
-g++ M10.cpp M10Decoder.cpp M10GeneralParser.cpp M10GtopParser.cpp M10TrimbleParser.cpp AudioFile.cpp -lm -o m10 -std=c++11
+#echo "Building M10 Demodulator."
+#cd ../m10/
+#g++ M10.cpp M10Decoder.cpp M10GeneralParser.cpp M10GtopParser.cpp M10TrimbleParser.cpp AudioFile.cpp -lm -o m10 -std=c++11
 
 echo "Building iMet Demodulator."
 cd ../imet/
@@ -65,7 +65,7 @@ cp ../mk2a/mk2a_lms1680 .
 
 cp ../demod/mod/rs41mod .
 cp ../demod/mod/dfm09mod .
-#cp ../demod/mod/m10mod .
+cp ../demod/mod/m10mod .
 cp ../demod/mod/rs92mod .
 cp ../demod/mod/lms6Xmod .
 cp ../demod/mod/meisei100mod .

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -12,12 +12,16 @@ import argparse
 import os
 import sys
 import time
+import traceback
 import subprocess
 
 
 # Dictionary of available processing types.
 
 processing_type = {
+    #
+    #   CSDR Decoding - Just for testing.
+    #
     # # RS41 Decoding
     # 'rs41_csdr': {
     #     # Decode a RS41 using a CSDR processing chain to do FM demodulation
@@ -117,7 +121,7 @@ processing_type = {
     # # RS41 Decoding
     'rs41_fsk_demod': {
         # Shift up to ~24 khz, and then pass into fsk_demod.
-        'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../fsk_demod --cs16 -b 1 -u 45000 --stats=100 2 96000 4800 - - 2>stats.txt |",
+        'demod' : "| csdr shift_addition_cc 0.125 2>/dev/null | csdr convert_f_s16 | ./tsrc - - 0.500 |  ../fsk_demod --cs16 -b 1 -u 24000 --stats=100 2 48000 4800 - - 2>stats.txt |",
 
         # Decode using rs41ecc
         'decode': "../rs41mod --ecc --ptu --crc --bin --json 2>/dev/null",
@@ -139,7 +143,7 @@ processing_type = {
     'm10_fsk_demod': {
         # Shift up to ~24 khz, and then pass into fsk_demod.
         'demod' : "| csdr shift_addition_cc 0.25 2>/dev/null | csdr convert_f_s16 | ../tsrc - - 1.0016666 -c | ../fsk_demod --cs16 -b 1 -u 45000 --stats=100 2 96160 9616 - - 2>stats.txt | python ./bit_to_samples.py 57696 9616 | sox -t raw -r 57696 -e unsigned-integer -b 8 -c 1 - -r 57696 -b 8 -t wav - 2>/dev/null| ",
-        'decode': "../m10 -b -b2 2>/dev/null",
+        'decode': "tee test.wav | ../m10mod --json -vvv 2>/dev/null",
         # Count the number of telemetry lines.
         "post_process" : "| wc -l",
         'files' : "./generated/m10*"
@@ -150,7 +154,7 @@ processing_type = {
         #python ./bit_to_samples.py 50000 2500 | sox -t raw -r 50k -e unsigned-integer -b 8 -c 1 - -r 50000 -b 8 -t wav - 2>/dev/null| 
         #../dfm09ecc -vv --json --dist --auto
 
-        'demod': '| csdr shift_addition_cc 0.25000 2>/dev/null | csdr convert_f_s16 | ../tsrc - - 1.041666 | ../fsk_demod --cs16 -b 1 -u 45000 --stats=100 2 100000 2500 - - 2>stats.txt |',#' python ./bit_to_samples.py 50000 2500 | sox -t raw -r 50k -e unsigned-integer -b 8 -c 1 - -r 50000 -b 8 -t wav - 2>/dev/null| ',
+        'demod': '| csdr shift_addition_cc 0.125000 2>/dev/null | csdr convert_f_s16 | ../tsrc - - 0.5208| ../fsk_demod --cs16 -b 1250 -u 23750 --stats=100 2 50000 2500 - - 2>stats.txt |',#' python ./bit_to_samples.py 50000 2500 | sox -t raw -r 50k -e unsigned-integer -b 8 -c 1 - -r 50000 -b 8 -t wav - 2>/dev/null| ',
         'decode': '../dfm09mod -vv --json --dist --auto --bin 2>/dev/null',
         "post_process" : " | grep frame |  wc -l", # ECC
         #"post_process" : "| grep -o '\[OK\]' | wc -l", # No ECC
@@ -205,7 +209,7 @@ processing_type = {
 # The input samples, which are in complex float IQ format, are shifted in frequency to where rtl_fm
 # expects them to be, and are also resampled to match rtl_fm's desired input rate.
 #
-_sample_fs = 96000.0 # Sample rate of input. Always 96k at the moment.
+_sample_fs = 96000.0 # Sample rate of input. Mostly 96k
 
 
 # # RS41
@@ -240,151 +244,151 @@ processing_type['rs41_rtlfm'] = {
 
 
 # # RS92
-# _fm_rate = 12000
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+_fm_rate = 12000
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
 
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
 
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
 
-# _demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
+_demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
 
 
-# processing_type['rs92_rtlfm'] = {
-#     'demod': _demod_command,
-#     # Decode using rs92ecc
-#     'decode': "../rs92mod -vx -v --crc --ecc --vel 2>/dev/null",
-#     #'decode': "../rs92ecc -vx -v --crc --ecc -r --vel 2>/dev/null", # For measuring No-ECC performance
-#     # Count the number of telemetry lines.
-#     "post_process" : " | grep M2513116 | wc -l",
-#     #"post_process" : " | grep \"errors: 0\" | wc -l",
-#     'files' : "./generated/rs92*.bin" 
-# }
+processing_type['rs92_rtlfm'] = {
+    'demod': _demod_command,
+    # Decode using rs92ecc
+    'decode': "../rs92mod -vx -v --crc --ecc --vel 2>/dev/null",
+    #'decode': "../rs92ecc -vx -v --crc --ecc -r --vel 2>/dev/null", # For measuring No-ECC performance
+    # Count the number of telemetry lines.
+    "post_process" : " | grep M2513116 | wc -l",
+    #"post_process" : " | grep \"errors: 0\" | wc -l",
+    'files' : "./generated/rs92*.bin" 
+}
 
 
 # # RS92-NGP (wider bandwidth)
-# _fm_rate = 28000
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+_fm_rate = 28000
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
 
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
 
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
 
-# _demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
+_demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
 
 
-# processing_type['rs92ngp_rtlfm'] = {
-#     'demod': _demod_command,
-#     # Decode using rs92ecc
-#     'decode': "../rs92mod -vx -v --crc --ecc --vel 2>/dev/null",
-#     #'decode': "../rs92ecc -vx -v --crc --ecc -r --vel 2>/dev/null", # For measuring No-ECC performance
-#     # Count the number of telemetry lines.
-#     "post_process" : "| grep P3213708 | wc -l",
-#     #"post_process" : " | grep \"errors: 0\" | wc -l",
-#     'files' : "./generated/rsngp*.bin" 
-# }
+processing_type['rs92ngp_rtlfm'] = {
+    'demod': _demod_command,
+    # Decode using rs92ecc
+    'decode': "../rs92mod -vx -v --crc --ecc --vel 2>/dev/null",
+    #'decode': "../rs92ecc -vx -v --crc --ecc -r --vel 2>/dev/null", # For measuring No-ECC performance
+    # Count the number of telemetry lines.
+    "post_process" : "| grep P3213708 | wc -l",
+    #"post_process" : " | grep \"errors: 0\" | wc -l",
+    'files' : "./generated/rsngp*.bin" 
+}
 
 # # DFM
-# _fm_rate = 15000 # Match what's in autorx.decode
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+_fm_rate = 15000 # Match what's in autorx.decode
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
 
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
 
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
-# # For some reason the DFM sample breaks type conversion - multiplying it by 0.9 seems to fix it.
-# _demod_command = "| csdr gain_ff 0.90 | %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 lowpass 2000 2>/dev/null |" % int(_fm_rate)
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
+# For some reason the DFM sample breaks type conversion - multiplying it by 0.9 seems to fix it.
+_demod_command = "| csdr gain_ff 0.90 | %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 lowpass 2000 2>/dev/null |" % int(_fm_rate)
 
-# processing_type['dfm_rtlfm'] = {
-#     'demod': _demod_command,
-#     'decode': "../dfm09mod -vv --json --dist --auto 2>/dev/null", # ECC
-#     #'decode': "../dfm09ecc -vv --ecc -r --auto 2>/dev/null", # No-ECC
-#     # Count the number of telemetry lines.
-#     "post_process" : " | grep frame |  wc -l", # ECC
-#     #"post_process" : "| grep -o '\[OK\]' | wc -l", # No ECC
-#     'files' : "./generated/dfm*.bin"
-# }
+processing_type['dfm_rtlfm'] = {
+    'demod': _demod_command,
+    'decode': "../dfm09mod -vv --json --dist --auto 2>/dev/null", # ECC
+    #'decode': "../dfm09ecc -vv --ecc -r --auto 2>/dev/null", # No-ECC
+    # Count the number of telemetry lines.
+    "post_process" : " | grep frame |  wc -l", # ECC
+    #"post_process" : "| grep -o '\[OK\]' | wc -l", # No ECC
+    'files' : "./generated/dfm*.bin"
+}
 
 
 # # M10
-# _fm_rate = 22000
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+_fm_rate = 22000
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
 
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
 
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
 
-# _demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
+_demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
 
-# processing_type['m10_rtlfm'] = {
-#     'demod': _demod_command,
-#     'decode': "../m10 -b -b2 2>/dev/null",
-#     # Count the number of telemetry lines.
-#     "post_process" : "| wc -l",
-#     'files' : "./generated/m10*.bin"
-# }
+processing_type['m10_rtlfm'] = {
+    'demod': _demod_command,
+    'decode': "../m10 -b -b2 2>/dev/null",
+    # Count the number of telemetry lines.
+    "post_process" : "| wc -l",
+    'files' : "./generated/m10*.bin"
+}
 
-# # iMet
-# _fm_rate = 15000
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
+# iMet
+_fm_rate = 15000
+# Calculate the necessary conversions
+_rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
+_shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
 
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
+_resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
 
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
+if _resample != 1.0:
+    # We will need to resample.
+    _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
+    _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
+else:
+    _resample_command = ""
 
-# _demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
+_demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
+_demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
+_demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
 
-# processing_type['imet4_rtlfm'] = {
-#     'demod': _demod_command,
-#     'decode': "../imet1rs_dft --json 2>/dev/null",
-#     # Count the number of telemetry lines.
-#     "post_process" : "| grep frame |  wc -l",
-#     'files' : "./generated/imet4*.bin"
-# }
+processing_type['imet4_rtlfm'] = {
+    'demod': _demod_command,
+    'decode': "../imet1rs_dft --json 2>/dev/null",
+    # Count the number of telemetry lines.
+    "post_process" : "| grep frame |  wc -l",
+    'files' : "./generated/imet4*.bin"
+}
 
 
 # LMS6 - 400 MHz version
@@ -448,36 +452,10 @@ processing_type['lms6-1680_rtlfm'] = {
 }
 
 
-# # RS_Detect
-# _fm_rate = 22000
-# #_fm_rate = 15000
-# # Calculate the necessary conversions
-# _rtlfm_oversampling = 8.0 # Viproz's hacked rtl_fm oversamples by 8x.
-# _shift = -2.0*_fm_rate/_sample_fs # rtl_fm tunes 'up' by rate*2, so we need to shift the signal down by this amount.
-
-# _resample = (_fm_rate*_rtlfm_oversampling)/_sample_fs
-
-# if _resample != 1.0:
-#     # We will need to resample.
-#     _resample_command = "csdr convert_f_s16 | ./tsrc - - %.4f | csdr convert_s16_f |" % _resample
-#     _shift = (-2.0*_fm_rate)/(_sample_fs*_resample)
-# else:
-#     _resample_command = ""
-
-# _demod_command = "| %s csdr shift_addition_cc %.5f 2>/dev/null | csdr convert_f_u8 |" % (_resample_command, _shift)
-# _demod_command += " ./rtl_fm_stdin -M fm -f 401000000 -F9 -s %d  2>/dev/null|" % (int(_fm_rate))
-# _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - highpass 20 2>/dev/null |" % int(_fm_rate)
-
-# processing_type['rs_detect_rtlfm'] = {
-#     'demod': _demod_command,
-#     'decode': "../rs_detect -z -t 8 2> /dev/null",
-#     # Grep out the line containing the detected sonde type.
-#     "post_process" : " | grep found",
-#     'files' : "./generated/*.bin"
-# }
 
 # DFT_Detect
 _fm_rate = 22000
+#_fm_rate = 30000
 #_fm_rate = 15000
 _sample_fs = 96000
 # Calculate the necessary conversions
@@ -499,15 +477,52 @@ _demod_command += " sox -t raw -r %d -e s -b 16 -c 1 - -r 48000 -b 8 -t wav - hi
 
 processing_type['dft_detect_rtlfm'] = {
     'demod': _demod_command,
-    'decode': "../dft_detect 2>/dev/null",
+    'decode': "../dft_detect -t 5 2>/dev/null",
     # Grep out the line containing the detected sonde type.
     "post_process" : " | grep \:",
     'files' : "./generated/*.bin"
 }
 
 
+# DFT_Detect - IQ version
 
-def run_analysis(mode, file_mask=None, shift=0.0, verbose=False, log_output = None, dry_run = False, quick=False):
+_sample_fs = 96000
+# Calculate the necessary conversions
+
+_resample = 48000.0/_sample_fs
+
+_demod_command = "| csdr convert_f_s16 | ./tsrc - - %.4f |" % (_resample)
+
+processing_type['dft_detect_iq'] = {
+    'demod': _demod_command,
+    'decode': "../dft_detect -t 5 --iq --dc - 48000 16 2>/dev/null",
+    # Grep out the line containing the detected sonde type.
+    "post_process" : " | grep \:",
+    'files' : "./generated/*.bin"
+}
+
+
+# DFT_Detect - IQ version - Wideband test
+
+_sample_fs = 500000
+# Calculate the necessary conversions
+_output_rate = 500000.0
+
+_resample = _output_rate/_sample_fs
+
+_demod_command = "| csdr convert_f_s16 | ./tsrc - - %.4f " % (_resample)
+_demod_command += "| sox -t raw -r %d -e s -b 16 -c 2 - -r %d -b 16 -t wav - 2>/dev/null |" % (_output_rate, _output_rate)
+
+processing_type['dft_detect_iq_wb'] = {
+    'demod': _demod_command,
+    'decode': "../dft_detect -t 5 --iq --dc --bw 500 2>/dev/null",
+    # Grep out the line containing the detected sonde type.
+    "post_process" : " | grep \:",
+    'files' : "./generated/lms6-1680*.bin"
+}
+
+
+def run_analysis(mode, file_mask=None, shift=0.0, verbose=False, log_output = None, dry_run = False, quick=False, show=False):
 
 
     _mode = processing_type[mode]
@@ -548,7 +563,12 @@ def run_analysis(mode, file_mask=None, shift=0.0, verbose=False, log_output = No
             _cmd += _shiftcmd
 
         # Add on the rest of the demodulation and decoding commands.
-        _cmd += _mode['demod'] + _mode['decode'] + _mode['post_process']
+        _cmd += _mode['demod'] + _mode['decode'] 
+        
+        if args.show:
+            _cmd += " | head -n 10"
+        else:
+            _cmd += _mode['post_process']
 
 
         if _first or dry_run:
@@ -564,6 +584,7 @@ def run_analysis(mode, file_mask=None, shift=0.0, verbose=False, log_output = No
             _output = subprocess.check_output(_cmd, shell=True, stderr=None)
             _output = _output.decode()
         except:
+            #traceback.print_exc()
             _output = "error"
 
         _runtime = time.time() - _start
@@ -592,6 +613,7 @@ if __name__ == "__main__":
     parser.add_argument("--shift", type=float, default=0.0, help="Shift the signal-under test by x Hz. Default is 0.")
     parser.add_argument("--batch", action='store_true', default=False, help="Run all tests, write results to results directory.")
     parser.add_argument("--quick", action='store_true', default=False, help="Only process the last sample file in the list (usually the strongest). Useful for checking the demodulators are still working.")
+    parser.add_argument("--show", action='store_true', default=False, help="Show the first few lines of output, instead of running the post-processing step.")
     args = parser.parse_args()
 
     # Check the mode is valid.
@@ -601,9 +623,11 @@ if __name__ == "__main__":
         sys.exit(1)
 
 
+    batch_modes = ['dfm_fsk_demod', 'rs41_fsk_demod', 'm10_fsk_demod', 'rs92_fsk_demod', 'lms6-400_fsk_demod', 'imet4_rtlfm']
+
     if args.batch:
-        for _mode in processing_type:
+        for _mode in batch_modes:
             _log_name = "./results/" + _mode + ".txt"
-            run_analysis(_mode, file_mask=None, shift=args.shift, verbose=args.verbose, log_output=_log_name, dry_run=args.dry_run, quick=args.quick)
+            run_analysis(_mode, file_mask=None, shift=args.shift, verbose=args.verbose, log_output=_log_name, dry_run=args.dry_run, quick=args.quick, show=args.show)
     else:
-        run_analysis(args.mode, args.files, shift=args.shift, verbose=args.verbose, dry_run=args.dry_run, quick=args.quick)
+        run_analysis(args.mode, args.files, shift=args.shift, verbose=args.verbose, dry_run=args.dry_run, quick=args.quick, show=args.show)

--- a/demod/mod/demod_mod.c
+++ b/demod/mod/demod_mod.c
@@ -15,6 +15,8 @@
 
 #include "demod_mod.h"
 
+#define FM_GAIN (0.8)
+
 /* ------------------------------------------------------------------------------------ */
 
 
@@ -145,8 +147,11 @@ static int getCorrDFT(dsp_t *dsp) {
     float re_cx = 0.0;
     float xnorm = 1;
     ui32_t mpos = 0;
-
     ui32_t pos = dsp->sample_out;
+
+    double dc = 0.0;
+    int mp_ofs = 0;
+    float *sbuf = dsp->bufs;
 
     dsp->mv = 0.0;
     dsp->dc = 0.0;
@@ -155,20 +160,37 @@ static int getCorrDFT(dsp_t *dsp) {
     if (dsp->sample_out < dsp->L) return -2;
 
 
-    dsp->dc = get_bufmu(dsp, pos - dsp->sample_out); //oder unten: dft_dc = creal(X[0])/(K+L);
-    // wenn richtige Stelle (Varianz pruefen, kein M10-carrier?), dann von bufs[] subtrahieren
-
-
-    for (i = 0; i < dsp->K + dsp->L; i++) (dsp->DFT).xn[i] = dsp->bufs[(pos+dsp->M -(dsp->K + dsp->L-1) + i) % dsp->M];
+    if (dsp->opt_iq > 1 && dsp->opt_dc) {
+        mp_ofs = (dsp->sps-1)/2;
+        sbuf = dsp->fm_buffer;
+    }
+    else {
+        sbuf = dsp->bufs;
+    }
+    for (i = 0; i < dsp->K + dsp->L; i++) (dsp->DFT).xn[i] = sbuf[(pos+dsp->M -(dsp->K + dsp->L-1) + i) % dsp->M];
     while (i < dsp->DFT.N) (dsp->DFT).xn[i++] = 0.0;
+
 
     rdft(&dsp->DFT, dsp->DFT.xn, dsp->DFT.X);
 
-    // dft_dc = creal(dsp->DFT.X[0])/dsp->DFT.N;
+
+    if (dsp->opt_dc) {
+        //X[0] = 0; // nicht ueber gesamte Laenge ... M10
+        //
+        // L < K ?  // only last 2L samples (avoid M10 carrier offset)
+        dc = 0.0;
+        for (i = dsp->K - dsp->L; i < dsp->K + dsp->L; i++) dc += (dsp->DFT).xn[i];
+        dc /= 2.0*(float)dsp->L;
+        dsp->DFT.X[0] -= dsp->DFT.N * dc  ;//* 0.95;
+        Nidft(&dsp->DFT, dsp->DFT.X, (dsp->DFT).cx);
+        for (i = 0; i < dsp->DFT.N; i++) (dsp->DFT).xn[i] = creal((dsp->DFT).cx[i])/(float)dsp->DFT.N;
+    }
 
     for (i = 0; i < dsp->DFT.N; i++) dsp->DFT.Z[i] = dsp->DFT.X[i]*dsp->DFT.Fm[i];
 
     Nidft(&dsp->DFT, dsp->DFT.Z, dsp->DFT.cx);
+
+    if (fabs(dc) < 0.5) dsp->dc = dc;
 
 
     // relativ Peak - Normierung erst zum Schluss;
@@ -192,15 +214,22 @@ static int getCorrDFT(dsp_t *dsp) {
 
     //xnorm = sqrt(dsp->qs[(mpos + 2*dsp->M) % dsp->M]); // Nvar = L
     xnorm = 0.0;
-    for (i = 0; i < dsp->L; i++) xnorm += dsp->bufs[(mpos-i + dsp->M) % dsp->M]*dsp->bufs[(mpos-i + dsp->M) % dsp->M];
+    for (i = 0; i < dsp->L; i++) xnorm += (dsp->DFT).xn[mp-i]*(dsp->DFT).xn[mp-i];
     xnorm = sqrt(xnorm);
 
     mx /= xnorm*(dsp->DFT).N;
+
+    if (dsp->opt_iq > 1 && dsp->opt_dc) mpos += mp_ofs;
 
     dsp->mv = mx;
     dsp->mv_pos = mpos;
 
     if (pos == dsp->sample_out) dsp->buffered = dsp->sample_out - mpos;
+
+// FM: s = gain * carg(w)/M_PI = gain * dphi / PI // gain=0.8
+// FM audio gain? dc relative to FM-envelope?!
+//
+    dsp->dDf = dsp->sr * dsp->dc / (2.0*FM_GAIN);  // remaining freq offset
 
     return mp;
 }
@@ -306,27 +335,50 @@ static int f32read_sample(dsp_t *dsp, float *s) {
     return 0;
 }
 
+typedef struct {
+    double sumIQx;
+    double sumIQy;
+    float avgIQx;
+    float avgIQy;
+    ui32_t cnt;
+    ui32_t maxcnt;
+    ui32_t maxlim;
+} iq_dc_t;
+static iq_dc_t IQdc;
+
 static int f32read_csample(dsp_t *dsp, float complex *z) {
 
-    if (dsp->bps == 32) {
-        float x = 0, y = 0;
+    float x, y;
 
-        if (fread( &x, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
-        if (fread( &y, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
-
-        *z = x + I*y;
+    if (dsp->bps == 32) { //float32
+        float f[2];
+        if (fread( f, dsp->bps/8, 2, dsp->fp) != 2) return EOF;
+        x = f[0];
+        y = f[1];
     }
-    else {  // dsp->bps == 8,16
-        short a = 0, b = 0;
+    else if (dsp->bps == 16) { //int16
+        short b[2];
+        if (fread( b, dsp->bps/8, 2, dsp->fp) != 2) return EOF;
+        x = b[0]/32768.0;
+        y = b[1]/32768.0;
+    }
+    else {  // dsp->bps == 8   //uint8
+        ui8_t u[2];
+        if (fread( u, dsp->bps/8, 2, dsp->fp) != 2) return EOF;
+        x = (u[0]-128)/128.0;
+        y = (u[1]-128)/128.0;
+    }
 
-        if (fread( &a, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
-        if (fread( &b, dsp->bps/8, 1, dsp->fp) != 1) return EOF;
+    *z = (x - IQdc.avgIQx) + I*(y - IQdc.avgIQy);
 
-        *z = a + I*b;
-
-        if (dsp->bps ==  8) { *z -= 128 + I*128; }
-        *z /= 128.0;
-        if (dsp->bps == 16) { *z /= 256.0; }
+    IQdc.sumIQx += x;
+    IQdc.sumIQy += y;
+    IQdc.cnt += 1;
+    if (IQdc.cnt == IQdc.maxcnt) {
+        IQdc.avgIQx = IQdc.sumIQx/(float)IQdc.maxcnt;
+        IQdc.avgIQy = IQdc.sumIQy/(float)IQdc.maxcnt;
+        IQdc.sumIQx = 0; IQdc.sumIQy = 0; IQdc.cnt = 0;
+        if (IQdc.maxcnt < IQdc.maxlim) IQdc.maxcnt *= 2;
     }
 
     return 0;
@@ -336,41 +388,72 @@ static int f32read_cblock(dsp_t *dsp) {
 
     int n;
     int len;
+    float x, y;
 
     len = dsp->decM;
 
     if (dsp->bps == 8) { //uint8
         ui8_t u[2*dsp->decM];
         len = fread( u, dsp->bps/8, 2*dsp->decM, dsp->fp) / 2;
-        for (n = 0; n < len; n++) dsp->decMbuf[n] = (u[2*n]-128)/128.0 + I*(u[2*n+1]-128)/128.0;
+        //for (n = 0; n < len; n++) dsp->decMbuf[n] = (u[2*n]-128)/128.0 + I*(u[2*n+1]-128)/128.0;
+        // u8: 0..255, 128 -> 0V
+        for (n = 0; n < len; n++) {
+            x = (u[2*n  ]-128)/128.0;
+            y = (u[2*n+1]-128)/128.0;
+            dsp->decMbuf[n] = (x-IQdc.avgIQx) + I*(y-IQdc.avgIQy);
+            IQdc.sumIQx += x;
+            IQdc.sumIQy += y;
+            IQdc.cnt += 1;
+            if (IQdc.cnt == IQdc.maxcnt) {
+                IQdc.avgIQx = IQdc.sumIQx/(float)IQdc.maxcnt;
+                IQdc.avgIQy = IQdc.sumIQy/(float)IQdc.maxcnt;
+                IQdc.sumIQx = 0; IQdc.sumIQy = 0; IQdc.cnt = 0;
+                if (IQdc.maxcnt < IQdc.maxlim) IQdc.maxcnt *= 2;
+            }
+        }
     }
     else if (dsp->bps == 16) { //int16
         short b[2*dsp->decM];
         len = fread( b, dsp->bps/8, 2*dsp->decM, dsp->fp) / 2;
-        for (n = 0; n < len; n++) dsp->decMbuf[n] = b[2*n]/32768.0 + I*b[2*n+1]/32768.0;
+        for (n = 0; n < len; n++) {
+            x = b[2*n  ]/32768.0;
+            y = b[2*n+1]/32768.0;
+            dsp->decMbuf[n] = (x-IQdc.avgIQx) + I*(y-IQdc.avgIQy);
+            IQdc.sumIQx += x;
+            IQdc.sumIQy += y;
+            IQdc.cnt += 1;
+            if (IQdc.cnt == IQdc.maxcnt) {
+                IQdc.avgIQx = IQdc.sumIQx/(float)IQdc.maxcnt;
+                IQdc.avgIQy = IQdc.sumIQy/(float)IQdc.maxcnt;
+                IQdc.sumIQx = 0; IQdc.sumIQy = 0; IQdc.cnt = 0;
+                if (IQdc.maxcnt < IQdc.maxlim) IQdc.maxcnt *= 2;
+            }
+        }
     }
     else { // dsp->bps == 32   //float32
         float f[2*dsp->decM];
         len = fread( f, dsp->bps/8, 2*dsp->decM, dsp->fp) / 2;
-        for (n = 0; n < len; n++) dsp->decMbuf[n] = f[2*n] + I*f[2*n+1];
+        for (n = 0; n < len; n++) {
+            x = f[2*n];
+            y = f[2*n+1];
+            dsp->decMbuf[n] = (x-IQdc.avgIQx) + I*(y-IQdc.avgIQy);
+            IQdc.sumIQx += x;
+            IQdc.sumIQy += y;
+            IQdc.cnt += 1;
+            if (IQdc.cnt == IQdc.maxcnt) {
+                IQdc.avgIQx = IQdc.sumIQx/(float)IQdc.maxcnt;
+                IQdc.avgIQy = IQdc.sumIQy/(float)IQdc.maxcnt;
+                IQdc.sumIQx = 0; IQdc.sumIQy = 0; IQdc.cnt = 0;
+                if (IQdc.maxcnt < IQdc.maxlim) IQdc.maxcnt *= 2;
+            }
+        }
     }
 
     return len;
 }
 
-
-float get_bufvar(dsp_t *dsp, int ofs) {
-    float mu  = dsp->xs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar;
-    float var = dsp->qs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar - mu*mu;
-    return var;
-}
-
-float get_bufmu(dsp_t *dsp, int ofs) {
-    float mu  = dsp->xs[(dsp->sample_out+dsp->M + ofs) % dsp->M]/dsp->Nvar;
-    return mu;
-}
-
-static int get_SNR(dsp_t *dsp) {
+/*
+static int get_SNR_rs41(dsp_t *dsp) {
 
     if (dsp->opt_iq)
     // if(dsp->rs_typ == RS41)
@@ -402,7 +485,7 @@ static int get_SNR(dsp_t *dsp) {
 
     return 0;
 }
-
+*/
 
 // decimate lowpass
 static float *ws_dec;
@@ -445,6 +528,35 @@ static int lowpass_init(float f, int taps, float **pws) {
     return taps;
 }
 
+
+static int lowpass_update(float f, int taps, float *ws) {
+    double *h, *w;
+    double norm = 0;
+    int n;
+
+    if (taps % 2 == 0) taps++; // odd/symmetric
+
+    if ( taps < 1 ) taps = 1;
+
+    h = (double*)calloc( taps+1, sizeof(double)); if (h == NULL) return -1;
+    w = (double*)calloc( taps+1, sizeof(double)); if (w == NULL) return -1;
+
+    for (n = 0; n < taps; n++) {
+        w[n] = 7938/18608.0 - 9240/18608.0*cos(2*M_PI*n/(taps-1)) + 1430/18608.0*cos(4*M_PI*n/(taps-1)); // Blackmann
+        h[n] = 2*f*sinc(2*f*(n-(taps-1)/2));
+        ws[n] = w[n]*h[n];
+        norm += ws[n]; // 1-norm
+    }
+    for (n = 0; n < taps; n++) {
+        ws[n] /= norm; // 1-norm
+    }
+
+    free(h); h = NULL;
+    free(w); w = NULL;
+
+    return taps;
+}
+
 static float complex lowpass(float complex buffer[], ui32_t sample, ui32_t taps, float *ws) {
     ui32_t n;
     double complex w = 0;
@@ -454,13 +566,22 @@ static float complex lowpass(float complex buffer[], ui32_t sample, ui32_t taps,
     return (float complex)w;
 }
 
+static float re_lowpass(float buffer[], ui32_t sample, ui32_t taps, float *ws) {
+    ui32_t n;
+    double w = 0;
+    for (n = 0; n < taps; n++) {
+        w += buffer[(sample+n+1)%taps]*ws[taps-1-n];
+    }
+    return (float)w;
+}
+
 
 int f32buf_sample(dsp_t *dsp, int inv) {
     float s = 0.0;
     float xneu, xalt;
 
     float complex z, w, z0;
-    double gain = 0.8;
+    double gain = FM_GAIN;
 
     double t = dsp->sample_in / (double)dsp->sr;
 
@@ -476,9 +597,10 @@ int f32buf_sample(dsp_t *dsp, int inv) {
                 if (dsp->sample_dec == s_reset) dsp->sample_dec = 0;
             }
             z = lowpass(dsp->decXbuffer, dsp->sample_dec, dsp->dectaps, ws_dec);
-
         }
         else if ( f32read_csample(dsp, &z) == EOF ) return EOF;
+
+        z *= cexp(-t*2*M_PI*dsp->Df*I);
 
         // IF-lowpass
         if (dsp->opt_lp) {
@@ -486,21 +608,22 @@ int f32buf_sample(dsp_t *dsp, int inv) {
             z = lowpass(dsp->lpIQ_buf, dsp->sample_in, dsp->lpIQtaps, dsp->ws_lpIQ);
         }
 
-        dsp->raw_iqbuf[dsp->sample_in % dsp->N_IQBUF] = z;
 
-        //z *= cexp(-t*2*M_PI*dsp->df*I);
         z0 = dsp->rot_iqbuf[(dsp->sample_in-1 + dsp->N_IQBUF) % dsp->N_IQBUF];
         w = z * conj(z0);
         s = gain * carg(w)/M_PI;
+
         dsp->rot_iqbuf[dsp->sample_in % dsp->N_IQBUF] = z;
 
-        /*  //if (rs_type==rs41) get_SNR(dsp);
-            // rs41, constant amplitude, avg/filter
-            int n;
-            double r = 0.0;
-            for (n = 0; n < dsp->sps; n++) r += cabs(dsp->rot_iqbuf[(dsp->sample_in - n + dsp->N_IQBUF) % dsp->N_IQBUF]);
-            r /= (float)n;
-        */
+
+        // FM-lowpass
+        if (dsp->opt_lp) {
+            dsp->lpFM_buf[dsp->sample_in % dsp->lpFMtaps] = s;
+            s = re_lowpass(dsp->lpFM_buf, dsp->sample_in, dsp->lpFMtaps, dsp->ws_lpFM);
+        }
+
+        dsp->fm_buffer[(dsp->sample_in - dsp->lpFMtaps/2 + dsp->M) % dsp->M] = s;
+
 
         if (dsp->opt_iq >= 2)
         {
@@ -562,7 +685,7 @@ int f32buf_sample(dsp_t *dsp, int inv) {
     }
 
     if (inv) s = -s;
-    dsp->bufs[dsp->sample_in % dsp->M] = s - dsp->dc_ofs;
+    dsp->bufs[dsp->sample_in % dsp->M] = s;
 
     xneu = dsp->bufs[(dsp->sample_in  ) % dsp->M];
     xalt = dsp->bufs[(dsp->sample_in+dsp->M - dsp->Nvar) % dsp->M];
@@ -587,17 +710,19 @@ static int read_bufbit(dsp_t *dsp, int symlen, char *bits, ui32_t mvp, int pos) 
 
     double sum = 0.0;
 
+    // bei symlen=2 (Manchester) kein dc noetig: -dc+dc=0 ;
+    // allerdings M10-header mit symlen=1
 
     rbitgrenze += dsp->sps;
     do {
-        sum += dsp->bufs[(rcount + mvp + dsp->M) % dsp->M];
+        sum += dsp->bufs[(rcount + mvp + dsp->M) % dsp->M] - dsp->dc;
         rcount++;
     } while (rcount < rbitgrenze);  // n < dsp->sps
 
     if (symlen == 2) {
         rbitgrenze += dsp->sps;
         do {
-            sum -= dsp->bufs[(rcount + mvp + dsp->M) % dsp->M];
+            sum -= dsp->bufs[(rcount + mvp + dsp->M) % dsp->M] - dsp->dc;
             rcount++;
         } while (rcount < rbitgrenze);  // n < dsp->sps
     }
@@ -623,6 +748,8 @@ static int headcmp(dsp_t *dsp, int opt_dc) {
     int len = dsp->hdrlen/dsp->symhd;
     int inv = dsp->mv < 0;
 
+    if (opt_dc == 0 || dsp->opt_iq > 1) dsp->dc = 0; // reset? e.g. 2nd pass
+
     if (dsp->symhd != 1) step = 2;
     if (inv) sign=1;
 
@@ -637,51 +764,7 @@ static int headcmp(dsp_t *dsp, int opt_dc) {
         len--;
     }
 
-    if (opt_dc && errs < 3) {
-        dsp->dc_ofs += dsp->dc;
-    }
-
     return errs;
-}
-
-int get_fqofs_rs41(dsp_t *dsp, ui32_t mvp, float *freq, float *snr) {
-    int j;
-    int buf_start;
-    int presamples;
-
-    // if(dsp->rs_typ == RS41_PREAMBLE) ...
-    if (dsp->opt_iq)
-    {
-        presamples = 256*dsp->sps;
-
-        if (presamples > dsp->DFT.N2) presamples = dsp->DFT.N2;
-
-        buf_start = mvp - dsp->hdrlen*dsp->sps - presamples;
-
-        while (buf_start < 0) buf_start += dsp->N_IQBUF;
-
-        for (j = 0; j < dsp->DFT.N2; j++) {
-            dsp->DFT.Z[j] = dsp->DFT.win[j]*dsp->raw_iqbuf[(buf_start+j) % dsp->N_IQBUF];
-        }
-        while (j < dsp->DFT.N) dsp->DFT.Z[j++] = 0;
-
-        raw_dft(&dsp->DFT, dsp->DFT.Z);
-        dsp->df = bin2freq(&dsp->DFT, max_bin(&dsp->DFT, dsp->DFT.Z));
-
-        // if |df|<eps, +-2400Hz dominant (rs41)
-        if (fabs(dsp->df) > 1000.0) dsp->df = 0.0;
-
-
-        dsp->sample_posframe = dsp->sample_in;  // > sample_out  //mvp - dsp->hdrlen*dsp->sps;
-        dsp->sample_posnoise = mvp + dsp->sr*7/8.0; // rs41
-
-
-        *freq = dsp->df;
-        *snr = dsp->SNRdB;
-    }
-    else return -1;
-
-    return 0;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -698,6 +781,10 @@ int read_slbit(dsp_t *dsp, int *bit, int inv, int ofs, int pos, float l, int spi
     //double l = 1.0;
 
     double bg = pos*dsp->symlen*dsp->sps;
+
+    double dc = 0.0;
+
+    if (dsp->opt_dc && dsp->opt_iq < 2) dc = dsp->dc;
 
     if (pos == 0) {
         bg = 0;
@@ -718,6 +805,7 @@ int read_slbit(dsp_t *dsp, int *bit, int inv, int ofs, int pos, float l, int spi
                           +dsp->bufs[(dsp->sample_out-dsp->buffered+1 + ofs + dsp->M) % dsp->M]);
                 sample = avg + scale*(sample - avg); // spikes
             }
+            sample -= dc;
 
             if ( l < 0 || (mid-l < dsp->sc && dsp->sc < mid+l)) sum -= sample;
 
@@ -737,6 +825,7 @@ int read_slbit(dsp_t *dsp, int *bit, int inv, int ofs, int pos, float l, int spi
                       +dsp->bufs[(dsp->sample_out-dsp->buffered+1 + ofs + dsp->M) % dsp->M]);
             sample = avg + scale*(sample - avg); // spikes
         }
+            sample -= dc;
 
         if ( l < 0 || (mid-l < dsp->sc && dsp->sc < mid+l)) sum += sample;
 
@@ -752,6 +841,11 @@ int read_slbit(dsp_t *dsp, int *bit, int inv, int ofs, int pos, float l, int spi
 
 /* -------------------------------------------------------------------------- */
 
+#define IF_SAMPLE_RATE      48000
+#define IF_SAMPLE_RATE_MIN  32000
+
+#define IF_TRANSITION_BW (4e3)  // 4kHz transition width
+#define FM_TRANSITION_BW (2e3)  // 2kHz transition width
 
 #define SQRT2 1.4142135624   // sqrt(2)
 // sigma = sqrt(log(2)) / (2*PI*BT):
@@ -791,13 +885,14 @@ int init_buffers(dsp_t *dsp) {
 
     if (dsp->opt_iq == 5)
     {
-        int IF_sr = 48000; // designated IF sample rate
+        int IF_sr = IF_SAMPLE_RATE; // designated IF sample rate
         int decM = 1; // decimate M:1
         int sr_base = dsp->sr;
         float f_lp; // dec_lowpass: lowpass_bandwidth/2
         float t_bw; // dec_lowpass: transition_bandwidth
         int taps; // dec_lowpass: taps
 
+        if (dsp->opt_IFmin) IF_sr = IF_SAMPLE_RATE_MIN;
         if (IF_sr > sr_base) IF_sr = sr_base;
         if (IF_sr < sr_base) {
             while (sr_base % IF_sr) IF_sr += 1;
@@ -805,7 +900,11 @@ int init_buffers(dsp_t *dsp) {
         }
 
         f_lp = (IF_sr+20e3)/(4.0*sr_base);
-        t_bw = (IF_sr-20e3)/*/2.0*/; if (t_bw < 0) t_bw = 8e3;
+        t_bw = (IF_sr-20e3)/*/2.0*/;
+        if (dsp->opt_IFmin) {
+            t_bw = (IF_sr-12e3);
+        }
+        if (t_bw < 0) t_bw = 10e3;
         t_bw /= sr_base;
         taps = 4.0/t_bw; if (taps%2==0) taps++;
 
@@ -871,15 +970,46 @@ int init_buffers(dsp_t *dsp) {
         int taps; // lowpass taps: 4*sr/transition_bw
 
         // IF lowpass
-        taps = 4*dsp->sr/4e3; if (taps%2==0) taps++; // 4kHz transition
-        f_lp = dsp->lpIQ_bw/(float)dsp->sr/2.0;
-        taps = lowpass_init(f_lp, taps, &dsp->ws_lpIQ); if (taps < 0) return -1;
+        f_lp = 24e3; // default
+        if (dsp->lpIQ_bw) f_lp = dsp->lpIQ_bw/(float)dsp->sr/2.0;
+        taps = 4*dsp->sr/IF_TRANSITION_BW; if (taps%2==0) taps++;
+        taps = lowpass_init(1.5*f_lp, taps, &dsp->ws_lpIQ0); if (taps < 0) return -1;
+        taps = lowpass_init(f_lp, taps, &dsp->ws_lpIQ1); if (taps < 0) return -1;
 
+        dsp->lpIQ_fbw = f_lp;
         dsp->lpIQtaps = taps;
         dsp->lpIQ_buf = calloc( dsp->lpIQtaps+3, sizeof(float complex));
         if (dsp->lpIQ_buf == NULL) return -1;
 
-        // dc-offset: if not centered, (aquisition) lowpass bw = lpIQ_bw + 4kHz
+        dsp->ws_lpIQ = dsp->ws_lpIQ1;
+        // dc-offset: if not centered, (acquisition) filter bw = lpIQ_bw + 4kHz
+        // coarse acquisition:
+        if (dsp->opt_dc) {
+            dsp->locked = 0;
+            dsp->ws_lpIQ = dsp->ws_lpIQ0;
+            //taps = lowpass_update(1.5*dsp->lpIQ_fbw, dsp->lpIQtaps, dsp->ws_lpIQ); if (taps < 0) return -1;
+        }
+        // locked:
+        //taps = lowpass_update(dsp->lpIQ_fbw, dsp->lpIQtaps, dsp->ws_lpIQ); if (taps < 0) return -1;
+
+
+        // FM lowpass
+        f_lp = 10e3; // default
+        if (dsp->lpFM_bw > 0) f_lp = dsp->lpFM_bw/(float)dsp->sr;
+        taps = 4*dsp->sr/FM_TRANSITION_BW; if (taps%2==0) taps++;
+        taps = lowpass_init(f_lp, taps, &dsp->ws_lpFM); if (taps < 0) return -1;
+
+        dsp->lpFMtaps = taps;
+        dsp->lpFM_buf = calloc( dsp->lpFMtaps+3, sizeof(float complex));
+        if (dsp->lpFM_buf == NULL) return -1;
+    }
+
+    memset(&IQdc, 0, sizeof(IQdc));
+    IQdc.maxlim = dsp->sr;
+    IQdc.maxcnt = IQdc.maxlim/32; // 32,16,8,4,2,1
+    if (dsp->decM > 1) {
+        IQdc.maxlim *= dsp->decM;
+        IQdc.maxcnt *= dsp->decM;
     }
 
 
@@ -982,11 +1112,10 @@ int init_buffers(dsp_t *dsp) {
         if (dsp->nch < 2) return -1;
 
         dsp->N_IQBUF = dsp->DFT.N;
-        dsp->raw_iqbuf = calloc(dsp->N_IQBUF+1, sizeof(float complex));  if (dsp->raw_iqbuf == NULL) return -1;
         dsp->rot_iqbuf = calloc(dsp->N_IQBUF+1, sizeof(float complex));  if (dsp->rot_iqbuf == NULL) return -1;
-
-        dsp->len_sq = dsp->sps*8;
     }
+
+    dsp->fm_buffer = (float *)calloc( M+1, sizeof(float));  if (dsp->fm_buffer == NULL) return -1; // dsp->bufs[]
 
 
     return K;
@@ -1011,10 +1140,11 @@ int free_buffers(dsp_t *dsp) {
 
     if (dsp->opt_iq)
     {
-        if (dsp->raw_iqbuf) { free(dsp->raw_iqbuf); dsp->raw_iqbuf = NULL; }
         if (dsp->rot_iqbuf) { free(dsp->rot_iqbuf); dsp->rot_iqbuf = NULL; }
     }
 
+
+    // decimate
     if (dsp->opt_iq == 5)
     {
         if (dsp->decXbuffer) { free(dsp->decXbuffer); dsp->decXbuffer = NULL; }
@@ -1024,11 +1154,18 @@ int free_buffers(dsp_t *dsp) {
         if (ws_dec) { free(ws_dec); ws_dec = NULL; }
     }
 
+    // IF lowpass
     if (dsp->opt_iq && dsp->opt_lp)
     {
-        if (dsp->ws_lpIQ)  { free(dsp->ws_lpIQ);  dsp->ws_lpIQ  = NULL; }
+        if (dsp->ws_lpIQ0) { free(dsp->ws_lpIQ0); dsp->ws_lpIQ0 = NULL; }
+        if (dsp->ws_lpIQ1) { free(dsp->ws_lpIQ1); dsp->ws_lpIQ1 = NULL; }
         if (dsp->lpIQ_buf) { free(dsp->lpIQ_buf); dsp->lpIQ_buf = NULL; }
+
+        if (dsp->ws_lpFM)  { free(dsp->ws_lpFM);  dsp->ws_lpFM  = NULL; }
+        if (dsp->lpFM_buf) { free(dsp->lpFM_buf); dsp->lpFM_buf = NULL; }
     }
+
+    if (dsp->fm_buffer) { free(dsp->fm_buffer); dsp->fm_buffer = NULL; }
 
     return 0;
 }
@@ -1064,6 +1201,31 @@ int find_header(dsp_t *dsp, float thres, int hdmax, int bitofs, int opt_dc) {
         }
 
         if (dsp->mv > thres || dsp->mv < -thres) {
+
+            if (dsp->opt_dc) {  // Problem: FM-gain
+                if (dsp->opt_iq < 2) dsp->Df += dsp->dDf*0.4;
+                else {
+                    double ofs = fabs(dsp->dDf);  // (iq-decode controls FM-gain)
+                    if (ofs > 200.0)
+                    {
+                        dsp->Df += dsp->dDf * 2/3.0;
+                    }
+                    if (ofs > 1000.0) {  //dsp->opt_lp
+                        if (dsp->locked) {
+                            dsp->locked = 0;
+                            dsp->ws_lpIQ = dsp->ws_lpIQ0;
+                            // alt: lowpass_update(1.5*dsp->lpIQ_fbw, dsp->lpIQtaps, dsp->ws_lpIQ);
+                        }
+                    }
+                    else {
+                        if (dsp->locked == 0) {
+                            dsp->locked = 1;
+                            dsp->ws_lpIQ = dsp->ws_lpIQ1;
+                            // alt: lowpass_update(dsp->lpIQ_fbw, dsp->lpIQtaps, dsp->ws_lpIQ);
+                        }
+                    }
+                }
+            }
 
             if (dsp->mv_pos > mvpos0) {
 

--- a/demod/mod/demod_mod.h
+++ b/demod/mod/demod_mod.h
@@ -50,8 +50,6 @@ typedef struct {
     int K;
     float *match;
     float *bufs;
-    float dc_ofs;
-    float dc;
     float mv;
     ui32_t mv_pos;
     //
@@ -65,7 +63,6 @@ typedef struct {
     // IQ-data
     int opt_iq;
     int N_IQBUF;
-    float complex *raw_iqbuf;
     float complex *rot_iqbuf;
     float complex F1sum;
     float complex F2sum;
@@ -82,8 +79,12 @@ typedef struct {
     // DFT
     dft_t DFT;
 
-    double df;
-    int len_sq;
+    // dc offset
+    int opt_dc;
+    int locked;
+    double dc;
+    double Df;
+    double dDf;
 
     ui32_t sample_posframe;
     ui32_t sample_posnoise;
@@ -93,6 +94,7 @@ typedef struct {
     double SNRdB;
 
     // decimate
+    int opt_IFmin;
     int decM;
     ui32_t sr_base;
     ui32_t dectaps;
@@ -106,9 +108,19 @@ typedef struct {
     // IF: lowpass
     int opt_lp;
     int lpIQ_bw;
+    float lpIQ_fbw;
     int lpIQtaps; // ui32_t
+    float *ws_lpIQ0;
+    float *ws_lpIQ1;
     float *ws_lpIQ;
     float complex *lpIQ_buf;
+
+    // FM: lowpass
+    int lpFM_bw;
+    int lpFMtaps; // ui32_t
+    float *ws_lpFM;
+    float *lpFM_buf;
+	float *fm_buffer;
 
 } dsp_t;
 
@@ -125,10 +137,6 @@ typedef struct {
 float read_wav_header(pcm_t *, FILE *);
 int f32buf_sample(dsp_t *, int);
 int read_slbit(dsp_t *, int*, int, int, int, float, int);
-
-int get_fqofs_rs41(dsp_t *, ui32_t, float *, float *);
-float get_bufvar(dsp_t *, int);
-float get_bufmu(dsp_t *, int);
 
 int init_buffers(dsp_t *);
 int free_buffers(dsp_t *);

--- a/demod/mod/lms6Xmod.c
+++ b/demod/mod/lms6Xmod.c
@@ -477,7 +477,7 @@ static int get_GPStime(gpx_t *gpx, int crc_err) {
         gpstow_start = gpstime; // time elapsed since start-up?
         if (gpx->week > 0 && gpstime/1000.0 < time_elapsed_sec) gpx->week += 1;
     }
-    gpx->gpstow = gpstime;
+    gpx->gpstow = gpstime; // tow/ms
 
     ms = gpstime % 1000;
     gpstime /= 1000;
@@ -517,6 +517,7 @@ static int get_GPStime_X(gpx_t *gpx) {
     }
 
     gpx->gpstowX = *f64;
+    gpx->gpstow = (ui32_t)(gpx->gpstowX*1e3); // tow/ms
     tow_u4 = (ui32_t)gpx->gpstowX;
     gpstime = tow_u4;
     gpx->gpssec = tow_u4;
@@ -923,6 +924,7 @@ static void proc_frame(gpx_t *gpx, int len) {
 int main(int argc, char **argv) {
 
     int option_inv = 0;    // invertiert Signal
+    int option_min = 0;
     int option_iq = 0;
     int option_lp = 0;
     int option_dc = 0;
@@ -1049,6 +1051,9 @@ int main(int argc, char **argv) {
         }
         else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
         else if   (strcmp(*argv, "--dc") == 0) { option_dc = 1; }
+        else if   (strcmp(*argv, "--min") == 0) {
+            option_min = 1;
+        }
         else if   (strcmp(*argv, "--json") == 0) {
             gpx->option.jsn = 1;
             gpx->option.ecc = 1;
@@ -1109,9 +1114,12 @@ int main(int argc, char **argv) {
     dsp.hdrlen = strlen(rawheader);
     dsp.BT = 1.2; // bw/time (ISI) // 1.0..2.0  // BT(lmsX) < BT(lms6) ? -> init_buffers()
     dsp.h = 0.9;  // 0.95 modulation index
-    dsp.lpIQ_bw = 8e3;
     dsp.opt_iq = option_iq;
     dsp.opt_lp = option_lp;
+    dsp.lpIQ_bw = 8e3; // IF lowpass bandwidth
+    dsp.lpFM_bw = 6e3; // FM audio lowpass
+    dsp.opt_dc = option_dc;
+    dsp.opt_IFmin = option_min;
 
     if ( dsp.sps < 8 ) {
         fprintf(stderr, "note: sample rate low (%.1f sps)\n", dsp.sps);
@@ -1160,8 +1168,8 @@ int main(int argc, char **argv) {
 
     while ( 1 )
     {
-
-        header_found = find_header(&dsp, thres, 3, bitofs, option_dc);
+                                                                        // FM-audio:
+        header_found = find_header(&dsp, thres, 3, bitofs, dsp.opt_dc); // optional 2nd pass: dc=0
         _mv = dsp.mv;
 
         if (header_found == EOF) break;

--- a/demod/mod/meisei100mod.c
+++ b/demod/mod/meisei100mod.c
@@ -336,7 +336,7 @@ int main(int argc, char **argv) {
             option_iq = 5;
         }
         else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
-//        else if ( (strcmp(*argv, "--dc") == 0) ) { option_dc = 1; }
+        else if ( (strcmp(*argv, "--dc") == 0) ) { option_dc = 1; }
         else if   (strcmp(*argv, "--json") == 0) {
             option_jsn = 1;
             option_ecc = 1;
@@ -382,9 +382,11 @@ int main(int argc, char **argv) {
     dsp.hdrlen = strlen(rawheader);
     dsp.BT = 1.2; // bw/time (ISI) // 1.0..2.0
     dsp.h = 2.4;  // 2.8
-    dsp.lpIQ_bw = 16e3;
     dsp.opt_iq = option_iq;
     dsp.opt_lp = option_lp;
+    dsp.lpIQ_bw = 16e3; // IF lowpass bandwidth
+    dsp.lpFM_bw = 4e3; // FM audio lowpass
+    dsp.opt_dc = option_dc;
 
     if ( dsp.sps < 8 ) {
         fprintf(stderr, "note: sample rate low (%.1f sps)\n", dsp.sps);
@@ -413,8 +415,8 @@ int main(int argc, char **argv) {
 
     while ( 1 )
     {
-
-        header_found = find_header(&dsp, thres, 1, bitofs, option_dc);
+                                                                        // FM-audio:
+        header_found = find_header(&dsp, thres, 1, bitofs, dsp.opt_dc); // optional 2nd pass: dc=0
         _mv = dsp.mv;
 
         if (header_found == EOF) break;
@@ -732,6 +734,8 @@ int main(int argc, char **argv) {
     }
 
     printf("\n");
+
+    free_buffers(&dsp);
 
     fclose(fp);
 

--- a/demod/mod/rs41mod.c
+++ b/demod/mod/rs41mod.c
@@ -1532,9 +1532,10 @@ static int find_binhead(FILE *fp, hdb_t *hdb, float *score) {
 int main(int argc, char *argv[]) {
 
     //int option_inv = 0;    // invertiert Signal
+    int option_min = 0;
     int option_iq = 0;
     int option_lp = 0;
-    int option_ofs = 0;
+    int option_dc = 0;
     int option_bin = 0;
     int wavloaded = 0;
     int sel_wavch = 0;     // audio channel: left
@@ -1608,13 +1609,8 @@ int main(int argc, char *argv[]) {
         else if   (strcmp(*argv, "--sat") == 0) { gpx.option.sat = 1; }
         else if   (strcmp(*argv, "--ptu") == 0) { gpx.option.ptu = 1; }
         else if   (strcmp(*argv, "--silent") == 0) { gpx.option.slt = 1; }
-        else if   (strcmp(*argv, "--json") == 0) {
-            gpx.option.jsn = 1;
-            gpx.option.ecc = 2;
-            gpx.option.crc = 1;
-        }
         else if   (strcmp(*argv, "--ch2") == 0) { sel_wavch = 1; }  // right channel (default: 0=left)
-        else if ( (strcmp(*argv, "--auto") == 0) ) { gpx.option.aut = 1; }
+        else if   (strcmp(*argv, "--auto") == 0) { gpx.option.aut = 1; }
         else if   (strcmp(*argv, "--bin") == 0) { option_bin = 1; }   // bit/byte binary input
         else if   (strcmp(*argv, "--ths") == 0) {
             ++argv;
@@ -1646,7 +1642,15 @@ int main(int argc, char *argv[]) {
             option_iq = 5;
         }
         else if   (strcmp(*argv, "--lp") == 0) { option_lp = 1; }  // IQ lowpass
-        else if   (strcmp(*argv, "--ofs") == 0) { option_ofs = 1; }
+        else if   (strcmp(*argv, "--dc") == 0) { option_dc = 1; }
+        else if   (strcmp(*argv, "--min") == 0) {
+            option_min = 1;
+        }
+        else if   (strcmp(*argv, "--json") == 0) {
+            gpx.option.jsn = 1;
+            gpx.option.ecc = 2;
+            gpx.option.crc = 1;
+        }
         else if   (strcmp(*argv, "--rawhex") == 0) { rawhex = 2; }  // raw hex input
         else if   (strcmp(*argv, "--xorhex") == 0) { rawhex = 2; xorhex = 1; }  // raw xor input
         else {
@@ -1705,9 +1709,12 @@ int main(int argc, char *argv[]) {
             dsp.hdrlen = strlen(rs41_header);
             dsp.BT = 0.5; // bw/time (ISI) // 0.3..0.5
             dsp.h = 0.6; //0.7;  // 0.7..0.8? modulation index abzgl. BT
-            dsp.lpIQ_bw = 8e3;
             dsp.opt_iq = option_iq;
             dsp.opt_lp = option_lp;
+            dsp.lpIQ_bw = 8e3; // IF lowpass bandwidth
+            dsp.lpFM_bw = 6e3; // FM audio lowpass
+            dsp.opt_dc = option_dc;
+            dsp.opt_IFmin = option_min;
 
             if ( dsp.sps < 8 ) {
                 fprintf(stderr, "note: sample rate low (%.1f sps)\n", dsp.sps);
@@ -1741,8 +1748,8 @@ int main(int argc, char *argv[]) {
             if (option_bin) {
                 header_found = find_binhead(fp, &hdb, &_mv);
             }
-            else {
-                header_found = find_header(&dsp, thres, 3, bitofs, 0);
+            else {                                                              // FM-audio:
+                header_found = find_header(&dsp, thres, 3, bitofs, dsp.opt_dc); // optional 2nd pass: dc=0
                 _mv = dsp.mv;
             }
             if (header_found == EOF) break;


### PR DESCRIPTION
Lots of changes here.
- dft_detect IQ input (48 kHz BW from rtl_fm) is now used by default for 400 MHz sondes, and for 1680 MHz RS92s. Wide FM demod is still used for LMS6-1680 sondes. The IF bandwidth for dft_detect has been tweaked to achieve similar performance to the 22 kHz FM demod approach, but still work OK up to +/- 5 kHz frequency offset for 400 MHz sondes. A sider 32 kHz IF bandwidth is used for RS92-NGP sondes.
- Changed to m10mod, using the new APRS ID.
- The frequency provided in the Habitat sentence comment now uses the frequency offset information from fsk_demod, if it is available.

