### PR TITLE
Migrate Docker Container from Alpine to Debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,60 +1,44 @@
-# -------------------
-# The build container
-# -------------------
-FROM alpine AS build
-WORKDIR /root
-
-# Update system packages and install build dependencies.
-RUN apk upgrade --no-cache && \
-  apk add --no-cache \
-  build-base \
-  cmake \
-  libusb-dev
-
-# Build RTL-SDR.
-ADD https://github.com/steve-m/librtlsdr/archive/master.zip /root/librtlsdr-master.zip
-RUN unzip librtlsdr-master.zip && \
-  rm librtlsdr-master.zip && \
-  cd librtlsdr-master && \
-  mkdir build && \
-  cd build && \
-  cmake -DCMAKE_INSTALL_PREFIX=/root/target/usr/local ../ && \
-  make && \
-  make install
-
-# Build the radiosonde_auto_rx decoders.
-COPY . /root/radiosonde_auto_rx
-RUN cd radiosonde_auto_rx/auto_rx && \
-  sh build.sh
-
-# -------------------------
-# The application container
-# -------------------------
-FROM alpine
+FROM debian:buster-slim
 EXPOSE 5000/tcp
 
-# Update system packages and install application dependencies.
-RUN apk upgrade --no-cache && \
-  apk add --no-cache \
-  coreutils \
-  libusb \
-  py3-crcmod \
-  py3-dateutil \
-  py3-flask \
-  py3-numpy \
-  py3-requests \
+# Update system packages and install build and application dependencies.
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  build-essential \
   python3 \
+  python3-crcmod \
+  python3-dateutil \
+  python3-flask \
+  python3-numpy \
+  python3-pip \
+  python3-requests \
+  python3-setuptools \
   rng-tools \
+  rtl-sdr \
   sox \
-  usbutils
+  usbutils && \
+  rm -rf /var/lib/apt/lists/*
 
 RUN pip3 --no-cache-dir install \
   flask-socketio
 
-# Copy required artefacts from the build container.
-COPY --from=build /root/target /
-COPY --from=build /root/radiosonde_auto_rx/auto_rx /opt/auto_rx/
+# Build the radiosonde_auto_rx binaries and copy auto_rx to /opt.
+COPY . /tmp/radiosonde_auto_rx
+RUN cd /tmp/radiosonde_auto_rx/auto_rx && \
+  sh build.sh && \
+  cd ../ && \
+  mv /tmp/radiosonde_auto_rx/auto_rx /opt/ && \
+  rm -rf /tmp/radiosonde_auto_rx
 
-# Run auto_rx.py
+# Remove packages that were only needed for building.
+RUN apt-get remove -y \
+  build-essential \
+  python3-pip \
+  python3-setuptools && \
+  apt-get autoremove -y && \
+  rm -rf /var/lib/apt/lists/*
+
+# Run auto_rx.py.
 WORKDIR /opt/auto_rx
 CMD ["python3", "/opt/auto_rx/auto_rx.py"]


### PR DESCRIPTION
Works around an issue with piping stdin in to `fsk_demod`, which only surfaces when built using `musl`. This prevents the effective use of the experimental decoders.

Alpine Linux uses `musl`, whereas Debian uses `glibc`, which doesn't appear to suffer from this issue, hence the shift to Debian.

The hope is this will be temporary, and that we'll be able to return to Alpine Linux in the future, as a Debian based container is far larger than an Alpine Linux based counterpart. 

Efforts to understand why this is an issue, and ideally a fix, are ongoing, with @darksidelemm and I having spent quite a bit of time on this already.