### PR TITLE
Use a Docker Build Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM debian:buster-slim
-EXPOSE 5000/tcp
+# -------------------
+# The build container
+# -------------------
+FROM debian:buster-slim AS build
 
-# Update system packages and install build and application dependencies.
+# Update system packages and install build dependencies.
 RUN apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
@@ -11,33 +13,46 @@ RUN apt-get update && \
   python3-dateutil \
   python3-flask \
   python3-numpy \
-  python3-pip \
+  python3-pip  \
+  python3-requests && \
+  rm -rf /var/lib/apt/lists/*
+
+# Install additional Python packages that aren't available through apt-get.
+RUN pip3 --no-cache-dir install \
+  flask-socketio
+
+# Copy in radiosonde_auto_rx and build the binaries.
+COPY . /root/radiosonde_auto_rx
+RUN cd /root/radiosonde_auto_rx/auto_rx && \
+  sh build.sh
+
+# -------------------------
+# The application container
+# -------------------------
+FROM debian:buster-slim
+EXPOSE 5000/tcp
+
+# Update system packages and install application dependencies.
+RUN apt-get update && \
+  apt-get upgrade -y && \
+  apt-get install -y \
+  python3 \
+  python3-crcmod \
+  python3-dateutil \
+  python3-flask \
+  python3-numpy \
   python3-requests \
-  python3-setuptools \
   rng-tools \
   rtl-sdr \
   sox \
   usbutils && \
   rm -rf /var/lib/apt/lists/*
 
-RUN pip3 --no-cache-dir install \
-  flask-socketio
+# Copy any additional Python packages from the build container.
+COPY --from=build /usr/local/lib/python3.7/dist-packages /usr/local/lib/python3.7/dist-packages
 
-# Build the radiosonde_auto_rx binaries and copy auto_rx to /opt.
-COPY . /tmp/radiosonde_auto_rx
-RUN cd /tmp/radiosonde_auto_rx/auto_rx && \
-  sh build.sh && \
-  cd ../ && \
-  mv /tmp/radiosonde_auto_rx/auto_rx /opt/ && \
-  rm -rf /tmp/radiosonde_auto_rx
-
-# Remove packages that were only needed for building.
-RUN apt-get remove -y \
-  build-essential \
-  python3-pip \
-  python3-setuptools && \
-  apt-get autoremove -y && \
-  rm -rf /var/lib/apt/lists/*
+# Copy auto_rx from the build container to /opt.
+COPY --from=build /root/radiosonde_auto_rx/auto_rx /opt/auto_rx
 
 # Run auto_rx.py.
 WORKDIR /opt/auto_rx


### PR DESCRIPTION
Reduces the size of the resulting container from 488 MB down to 175 MB.