### PR TITLE
station.cfg.example: s/gpsd_hostname/gpsd_host/

### DIFF
--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -108,7 +108,7 @@ station_code = SONDE
 # needs to be entered above.
 # For balloon chasing, chasemapper is much better suited: https://github.com/projecthorus/chasemapper
 gpsd_enabled = False
-gpsd_hostname = localhost
+gpsd_host = localhost
 gpsd_port = 2947
 
 


### PR DESCRIPTION
Left me confused for a while why I couldn't get it to connect to a remote GPSD instance 😄 