### PR TITLE
Remove timeout from the start script

### DIFF
--- a/auto_rx/auto_rx.sh
+++ b/auto_rx/auto_rx.sh
@@ -15,5 +15,5 @@ cd /home/pi/radiosonde_auto_rx/auto_rx/
 # Clean up old files
 rm log_power*.csv
 
-# Start auto_rx process with a 3 hour timeout.
-python auto_rx.py -t 180
+# Start auto_rx process
+python auto_rx.py


### PR DESCRIPTION
After spending some hours trying to find the cause of auto_rx stopping each time before a balloon can be received I finally found that in the start script the timeout defined in the station.cfg is overwritten. Hopefully this PR prevents the next person to waste this time...