### PR TITLE
Update index.html

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -249,7 +249,11 @@
                             if(autorx_config.habitat_enabled ==true){
                                 sonde_id_data.id = "<a href='http://sondehub.org/" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
                             } else {
-                                sonde_id_data.id = "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
+                                if(autorx_config.aprs_server == "radiosondy.info"){
+                                  sonde_id_data.id = "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + sonde_id + "' target='_blank'>" + sonde_id + "</$
+                                } else {
+                                  sonde_id_data.id = "<a href='https://aprs.fi/#!call=" + sonde_id + "&timerange=3600&tail=3600' target='_blank'>" + sonde_id + "</a>";
+                                }
                             }
                         }
 

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -249,6 +249,9 @@
                             if(autorx_config.habitat_enabled ==true){
                                 sonde_id_data.id = "<a href='http://sondehub.org/" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
                             }
+                            else {
+                                sonde_id_data.id = "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
+                            }
                         }
 
                         // Add SNR data, if it exists.

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -244,12 +244,11 @@
                         sonde_id_data.alt = sonde_id_data.alt.toFixed(1);
                         sonde_id_data.vel_v = sonde_id_data.vel_v.toFixed(1);
                         sonde_id_data.vel_h = (sonde_id_data.vel_h*3.6).toFixed(1);
-                        // Add a link to HabHub if we have habitat enabled.
+                        // Add a link to HabHub if we have habitat enabled otherwise add link to radiosondy.info.
                         if ("habitat_enabled" in autorx_config){
                             if(autorx_config.habitat_enabled ==true){
                                 sonde_id_data.id = "<a href='http://sondehub.org/" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
-                            }
-                            else {
+                            } else {
                                 sonde_id_data.id = "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
                             }
                         }


### PR DESCRIPTION
Support for radiosondy.info when set to disable sending data to Habitat. 

When sending data to Habitat is disabled. In index.html file, I added support after clicking on sonde ID to redirect to radiosondy.info website for sonde details.