### PR TITLE
O3 all the things.

### DIFF
--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -8,7 +8,7 @@
 # Build rs_detect.
 echo "Building dft_detect"
 cd ../scan/
-gcc dft_detect.c -lm -o dft_detect -DNOC34C50 -w
+gcc dft_detect.c -lm -o dft_detect -DNOC34C50 -w -Ofast
 
 echo "Building RS92/RS41/DFM/LMS6/iMS/M10/M20 Demodulators"
 #cd ../demod/
@@ -18,21 +18,21 @@ echo "Building RS92/RS41/DFM/LMS6/iMS/M10/M20 Demodulators"
 
 # New demodulators
 cd ../demod/mod/
-gcc -c demod_mod.c -w
-gcc -c bch_ecc_mod.c -w
+gcc -c demod_mod.c -w -O3
+gcc -c bch_ecc_mod.c -w -O3
 gcc rs41mod.c demod_mod.o bch_ecc_mod.o -lm -o rs41mod -w
-gcc dfm09mod.c demod_mod.o -lm -o dfm09mod -w
-gcc rs92mod.c demod_mod.o bch_ecc_mod.o -lm -o rs92mod -w
-gcc lms6mod.c demod_mod.o bch_ecc_mod.o -lm -o lms6mod -w
-gcc lms6Xmod.c demod_mod.o bch_ecc_mod.o -lm -o lms6Xmod -w
-gcc meisei100mod.c demod_mod.o bch_ecc_mod.o -lm -o meisei100mod -w
-gcc m10mod.c demod_mod.o -lm -o m10mod -w
-gcc mXXmod.c demod_mod.o -lm -o mXXmod -w
+gcc dfm09mod.c demod_mod.o -lm -O3 -o dfm09mod -w
+gcc rs92mod.c demod_mod.o bch_ecc_mod.o -lm -O3 -o rs92mod -w
+gcc lms6mod.c demod_mod.o bch_ecc_mod.o -lm -O3 -o lms6mod -w
+gcc lms6Xmod.c demod_mod.o bch_ecc_mod.o -lm -O3 -o lms6Xmod -w
+gcc meisei100mod.c demod_mod.o bch_ecc_mod.o -lm -O3 -o meisei100mod -w
+gcc m10mod.c demod_mod.o -lm -O3 -o m10mod -w
+gcc mXXmod.c demod_mod.o -lm -O3 -o mXXmod -w
 
 # Build LMS6-1680 Decoder
 echo "Building LMS6-1680 Demodulator."
 cd ../../mk2a/
-gcc mk2a_lms1680.c -lm -o mk2a_lms1680
+gcc mk2a_lms1680.c -lm -O3 -o mk2a_lms1680
 
 # Build M10 decoder
 #echo "Building M10 Demodulator."
@@ -41,13 +41,13 @@ gcc mk2a_lms1680.c -lm -o mk2a_lms1680
 
 echo "Building iMet Demodulator."
 cd ../imet/
-gcc imet1rs_dft.c -lm -o imet1rs_dft
+gcc imet1rs_dft.c -lm -O3 -o imet1rs_dft
 
 
 echo "Building fsk-demod utils from codec2"
 cd ../utils/
 # This produces a static build of fsk_demod
-gcc fsk_demod.c fsk.c modem_stats.c kiss_fftr.c kiss_fft.c -lm -o fsk_demod
+gcc fsk_demod.c fsk.c modem_stats.c kiss_fftr.c kiss_fft.c -lm -O3 -o fsk_demod
 # Build tsrc - this is only required for the test/test_demod.py script, so is not included in the standard build.
 #gcc tsrc.c -o tsrc -lm -lsamplerate
 # If running under OSX and using MacPorts, you may need to uncomment the following line to be able to find libsamplerate.


### PR DESCRIPTION
Enable compilation optimisations for everything. Roughly 50% speedup. 

Doesn't affect much as everything was running faster than realtime on a RPi 3, but might help on slower, or shared systems.