### PR TITLE
Add upload of all telemetry to Beta Sondehub DB

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -888,8 +888,19 @@ def main():
         exporter_functions.append(_rotator.add)
 
     if config["sondehub_enabled"]:
+        if config["habitat_upload_listener_position"] is False:
+            _sondehub_station_position = None
+        else:
+            _sondehub_station_position = (
+                config["station_lat"],
+                config["station_lon"],
+                config["station_alt"],
+            )
+        
         _sondehub = SondehubUploader(
             user_callsign=config["habitat_uploader_callsign"],
+            user_position=_sondehub_station_position,
+            user_antenna=config["habitat_uploader_antenna"],
             upload_rate=config["habitat_upload_rate"],
         )
 

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -777,7 +777,7 @@ def main():
             launch_notifications=config["email_launch_notifications"],
             landing_notifications=config["email_landing_notifications"],
             landing_range_threshold=config["email_landing_range_threshold"],
-            landing_altitude_threshold=config["email_landing_altitude_threshold"]
+            landing_altitude_threshold=config["email_landing_altitude_threshold"],
         )
         email_exporter = _email_notification
 
@@ -890,7 +890,7 @@ def main():
     if config["sondehub_enabled"]:
         _sondehub = SondehubUploader(
             user_callsign=config["habitat_uploader_callsign"],
-            upload_rate=config["habitat_upload_rate"]
+            upload_rate=config["habitat_upload_rate"],
         )
 
         exporter_objects.append(_sondehub)

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -25,6 +25,7 @@ from autorx.email_notification import EmailNotification
 from autorx.habitat import HabitatUploader
 from autorx.aprs import APRSUploader
 from autorx.ozimux import OziUploader
+from autorx.sondehub import SondehubUploader
 from autorx.rotator import Rotator
 from autorx.utils import (
     rtlsdr_test,
@@ -885,6 +886,15 @@ def main():
 
         exporter_objects.append(_rotator)
         exporter_functions.append(_rotator.add)
+
+    if config["sondehub_enabled"]:
+        _sondehub = SondehubUploader(
+            user_callsign=config["habitat_uploader_callsign"],
+            upload_rate=config["habitat_upload_rate"]
+        )
+
+        exporter_objects.append(_sondehub)
+        exporter_functions.append(_sondehub.add)
 
     _web_exporter = WebExporter(max_age=config["web_archive_age"])
     exporter_objects.append(_web_exporter)

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.4.1-beta3"
+__version__ = "1.4.1-beta4"
 
 
 # Global Variables

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -162,7 +162,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         # This setting is not exposed to users as it's only used for unit/int testing
         "habitat_url": "https://habitat.sondehub.org/",
         # New Sondehub DB Settings
-        "sondehub_enabled": True
+        "sondehub_enabled": True,
     }
 
     try:
@@ -496,7 +496,6 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 "Config - Did not find kml_refresh_rate setting, using default (10 seconds)."
             )
             auto_rx_config["kml_refresh_rate"] = 11
-
 
         # New Sondehub db Settings
         try:

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -161,6 +161,8 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         # For now, sondehub.org just acts as a proxy to habhub.org.
         # This setting is not exposed to users as it's only used for unit/int testing
         "habitat_url": "https://habitat.sondehub.org/",
+        # New Sondehub DB Settings
+        "sondehub_enabled": True
     }
 
     try:
@@ -494,6 +496,18 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 "Config - Did not find kml_refresh_rate setting, using default (10 seconds)."
             )
             auto_rx_config["kml_refresh_rate"] = 11
+
+
+        # New Sondehub db Settings
+        try:
+            auto_rx_config["sondehub_enabled"] = config.getboolean(
+                "habitat", "sondehub_enabled"
+            )
+        except:
+            logging.warning(
+                "Config - Did not find sondehub_enabled setting, using default (enabled)."
+            )
+            auto_rx_config["sondehub_enabled"] = True
 
         # If we are being called as part of a unit test, just return the config now.
         if no_sdr_test:

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -1173,7 +1173,6 @@ class SondeDecoder(object):
                 # Fix up the time.
                 _telemetry["datetime_dt"] = fix_datetime(_telemetry["datetime"])
 
-
             # LMS Specific Actions (LMS6, MK2LMS)
             if "LMS" in self.sonde_type:
                 # We are only provided with HH:MM:SS, so the timestamp needs to be fixed, just like with the iMet sondes

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -80,9 +80,9 @@ class SondeDecoder(object):
         "humidity": -1.0,
         "pressure": -1,
         "batt": -1,
-        "vel_h": 0.0,
-        "vel_v": 0.0,
-        "heading": 0.0,
+        "vel_h": -9999.0,
+        "vel_v": -9999.0,
+        "heading": -9999.0,
     }
     # Note: The decoders may also supply other fields, such as:
     # 'batt' - Battery voltage, in volts.

--- a/auto_rx/autorx/gps.py
+++ b/auto_rx/autorx/gps.py
@@ -20,8 +20,13 @@ def get_ephemeris(destination="ephemeris.dat"):
         ftp.cwd("gnss/data/daily/%s/brdc/" % datetime.datetime.utcnow().strftime("%Y"))
         # file name should look like YYYY/brdc/brdcDDD0.YYn.Z
         # ESA posts new file at 2200 UTC
-        ephemeris_time = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(hours=22)
-        download_file = "brdc%s0.%sn.gz" % (ephemeris_time.strftime("%j"), ephemeris_time.strftime("%y"))
+        ephemeris_time = datetime.datetime.now(
+            datetime.timezone.utc
+        ) - datetime.timedelta(hours=22)
+        download_file = "brdc%s0.%sn.gz" % (
+            ephemeris_time.strftime("%j"),
+            ephemeris_time.strftime("%y"),
+        )
         logging.debug(
             "GPS Grabber - Downloading ephemeris data file: %s" % download_file
         )

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -107,6 +107,7 @@ class SondehubUploader(object):
             "software_name": "radiosonde_auto_rx",
             "software_version": autorx.__version__,
             "uploader_callsign": self.user_callsign,
+            "time_received": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         }
 
         # Mandatory Fields

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -1,0 +1,345 @@
+#!/usr/bin/env python
+#
+#   radiosonde_auto_rx - Sondehub DB Uploader
+#
+#   Uploads telemetry to the 'new' SondeHub ElasticSearch cluster,
+#   in the new 'universal' format descried here:
+#   https://github.com/projecthorus/radiosonde_auto_rx/wiki/Suggested-Universal-Sonde-Telemetry-Format
+#
+#   Copyright (C) 2021  Mark Jessop <vk5qi@rfhead.net>
+#   Released under GNU GPL v3 or later
+#
+import autorx
+import datetime
+import glob
+import gzip
+import json
+import logging
+import os
+import requests
+import time
+from threading import Thread
+
+try:
+    # Python 2
+    from Queue import Queue
+except ImportError:
+    # Python 3
+    from queue import Queue
+
+
+class SondehubUploader(object):
+    """ Sondehub Uploader Class.
+
+    Accepts telemetry dictionaries from a decoder, buffers them up, and then compresses and uploads
+    them to the Sondehub Elasticsearch cluster.
+
+    """
+    SONDEHUB_URL = "https://api.v2.sondehub.org/sondes/telemetry"
+
+    # We require the following fields to be present in the incoming telemetry dictionary data
+    REQUIRED_FIELDS = [
+        "frame",
+        "id",
+        "datetime",
+        "lat",
+        "lon",
+        "alt",
+        "temp",
+        "type",
+        "freq",
+        "freq_float",
+        "datetime_dt",
+    ]
+
+
+    def __init__(self, 
+        upload_rate = 30,
+        upload_timeout = 20,
+        upload_retries = 5,
+        user_callsign = "N0CALL"
+        ):
+        """ Initialise and start a Sondehub uploader
+        
+        Args:
+            upload_rate (int): How often to upload batches of data.
+            upload_timeout (int): Upload timeout.
+
+        """
+
+        self.upload_rate = upload_rate
+        self.upload_timeout = upload_timeout
+        self.upload_retries = upload_retries
+        self.user_callsign = user_callsign
+
+        # Input Queue.
+        self.input_queue = Queue()
+
+        # Start queue processing thread.
+        self.input_processing_running = True
+        self.input_process_thread = Thread(target=self.process_queue)
+        self.input_process_thread.start()
+
+    def add(self, telemetry):
+        """ Add a dictionary of telemetry to the input queue. 
+
+        Args:
+            telemetry (dict): Telemetry dictionary to add to the input queue.
+
+        """
+
+        # Attempt to reformat the data.
+        _telem = self.reformat_data(telemetry)
+        #self.log_debug("Telem: %s" % str(_telem))
+
+        # Add it to the queue if we are running.
+        if self.input_processing_running and _telem:
+            self.input_queue.put(_telem)
+        else:
+            self.log_error("Processing not running, discarding.")
+
+
+    def reformat_data(self, telemetry):
+        """ Take an input dictionary and convert it to the universal format """
+
+        # Init output dictionary
+        _output = {
+            "software_name" : "radiosonde_auto_rx",
+            "software_version": autorx.__version__,
+            "uploader_callsign": self.user_callsign
+        }
+
+        # Mandatory Fields
+        # Datetime
+        try:
+            _output['datetime'] = telemetry['datetime_dt'].strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+        except Exception as e:
+            self.log_error("Error converting telemetry datetime to string - %s" % str(e))
+            self.log_debug("Offending datetime_dt: %s" % str(telemetry['datetime_dt']))
+            return None
+
+        # Type
+        if telemetry['type'].startswith("RS41"):
+            _output['manufacturer'] = 'Vaisala'
+            _output['type'] = 'RS41'
+            _output['serial'] = telemetry['id']
+            if 'subtype' in telemetry:
+                _output['subtype'] = telemetry['subtype']
+
+        elif telemetry["type"].startswith("DFM"):
+            _output['manufacturer'] = "Graw"
+            _output['type'] = "DFM"
+            _output['subtype'] = telemetry["type"]
+            _output['serial'] = telemetry["id"].split('-')[1]
+        
+        elif telemetry["type"].startswith("M10") or telemetry["type"].startswith("M20"):
+            _output['manufacturer'] = "Meteomodem"
+            _output['type'] = telemetry["type"]
+            # Strip off leading M10- or M20-
+            _output['serial'] = telemetry["id"][4:]
+
+        elif telemetry["type"] == "LMS6":
+            _output['manufacturer'] = "Lockheed Martin"
+            _output['type'] = "LMS6-400"
+            _output['serial'] = telemetry["id"].split('-')[1]
+
+        elif telemetry["type"] == "MK2LMS":
+            _output['manufacturer'] = "Lockheed Martin"
+            _output['type'] = "LMS6-1680"
+            _output['serial'] = telemetry["id"].split('-')[1]
+
+        elif telemetry["type"] == "IMET":
+            _output['manufacturer'] = "Intermet Systems"
+            _output['type'] = "iMet-4"
+            _output['serial'] = telemetry["id"].split('-')[1]
+
+        elif telemetry["type"] == "IMET5":
+            _output['manufacturer'] = "Intermet Systems"
+            _output['type'] = "iMet-54"
+            _output['serial'] = telemetry["id"].split('-')[1]
+
+        else:
+            self.log_error("Unknown Radiosonde Type %s" % telemetry['type'])
+            return None
+
+        # Frame Number
+        _output['frame'] = telemetry["frame"]
+
+        # Position
+        _output['lat'] = telemetry['lat']
+        _output['lon'] = telemetry['lon']
+        _output['alt'] = telemetry['alt']
+
+        # Optional Fields
+        if 'temp' in telemetry:
+            if telemetry['temp'] > -273.0:
+                _output['temp'] = telemetry['temp']
+        
+        if 'humidity' in telemetry:
+            if telemetry['humidity'] >= 0.0:
+                _output['humidity'] = telemetry['humidity']
+
+        if 'pressure' in telemetry:
+            if telemetry['pressure'] >= 0.0:
+                _output['pressure'] = telemetry['pressure']
+
+        if 'vel_v' in telemetry:
+            if telemetry['vel_v'] > -9999.0:
+                _output['vel_v'] = telemetry['vel_v']
+
+        if 'vel_h' in telemetry:
+            if telemetry['vel_h'] > -9999.0:
+                _output['vel_h'] = telemetry['vel_h']
+    
+        if 'heading' in telemetry:
+            if telemetry['heading'] > -9999.0:
+                _output['heading'] = telemetry['heading']
+
+        if 'sats' in telemetry:
+            _output['sats'] = telemetry['sats']
+
+        if 'batt' in telemetry:
+            if telemetry['batt'] >= 0.0:
+                _output['batt'] = telemetry['batt']
+
+        if 'aux' in telemetry:
+            _output['aux_data'] = telemetry['aux']
+
+        if 'freq_float' in telemetry:
+            _output['frequency'] = telemetry["freq_float"]
+
+        if 'bt' in telemetry:
+            _output['burst_timer'] = telemetry['bt']
+
+
+        # Handle the additional SNR and frequency estimation if we have it
+        if 'snr' in telemetry:
+            _output['snr'] = telemetry['snr']
+
+        if 'f_centre' in telemetry:
+            _freq = round(telemetry["f_centre"] / 1e3)
+            _output['frequency'] = _freq/1e3
+
+        return _output
+
+
+    def process_queue(self):
+        """ Process data from the input queue, and write telemetry to log files.
+        """
+        self.log_info("Started Sondehub Uploader Thread.")
+
+        while self.input_processing_running:
+
+            # Process everything in the queue.
+            _to_upload = []
+
+            while self.input_queue.qsize() > 0:
+                try:
+                    _to_upload.append(self.input_queue.get_nowait())
+                except Exception as e:
+                    self.log_error("Error grabbing telemetry from queue - %s" % str(e))
+
+            # Upload data!
+            if len(_to_upload) > 0:
+                self.upload_telemetry(_to_upload)
+
+            # Sleep while waiting for some new data.
+            for i in range(self.upload_rate):
+                time.sleep(1)
+                if self.input_processing_running == False:
+                    break
+
+        self.log_info("Stopped Sondehub Uploader Thread.")
+
+
+    def upload_telemetry(self,telem_list):
+        """ Upload an list of telemetry data to Sondehub """
+
+        _data_len = len(telem_list)
+
+        try:
+            _telem_json = json.dumps(telem_list).encode('utf-8')
+        except Exception as e:
+            self.log_error("Error serialising telemetry list for upload - %s" % str(e))
+            return
+
+        #_compressed_payload = gzip.compress(_telem_json)
+        _compressed_payload = _telem_json
+        #print(_telem_json)
+        #self.log_info("Pre-compression: %d bytes, post: %d bytes. %f compression ratio"% (len(_telem_json), len(_compressed_payload), len(_compressed_payload)/len(_telem_json)))
+
+        _retries = 0
+
+        # TODO: Decide on when we want to try and retry.
+        _start_time = time.time()
+        while _retries < self.upload_retries:
+            # Run the request.
+            try:
+                headers = {
+                    "User-Agent": "autorx-" + autorx.__version__, 
+                    #"Content-Encoding": "gzip"
+                    "Content-Type": "application/json"
+                }
+                _req = requests.put(
+                    self.SONDEHUB_URL,
+                    _compressed_payload,
+                    timeout=(self.upload_timeout, 6.1),
+                    headers=headers,
+                )
+            except Exception as e:
+                self.log_error("Upload Failed: %s" % str(e))
+                return
+
+            if _req.status_code == 200:
+                # 201 = Success, 403 = Success, sentence has already seen by others.
+                _upload_time = time.time() - _start_time
+                self.log_info(
+                    "Uploaded %d telemetry packets to Sondehub in %.1f seconds." % (_data_len, _upload_time)
+                )
+                _upload_success = True
+                break
+            else:
+                self.log_error(
+                    "Error uploading to Sondehub. Status Code: %d %s."
+                    % (_req.status_code, _req.text)
+                )
+                break
+
+
+    def close(self):
+        """ Close input processing thread. """
+        self.input_processing_running = False
+
+    def running(self):
+        """ Check if the uploader thread is running. 
+
+        Returns:
+            bool: True if the uploader thread is running.
+        """
+        return self.input_processing_running
+
+    def log_debug(self, line):
+        """ Helper function to log a debug message with a descriptive heading. 
+        Args:
+            line (str): Message to be logged.
+        """
+        logging.debug("Sondehub Uploader - %s" % line)
+
+    def log_info(self, line):
+        """ Helper function to log an informational message with a descriptive heading. 
+        Args:
+            line (str): Message to be logged.
+        """
+        logging.info("Sondehub Uploader - %s" % line)
+
+    def log_error(self, line):
+        """ Helper function to log an error message with a descriptive heading. 
+        Args:
+            line (str): Message to be logged.
+        """
+        logging.error("Sondehub Uploader - %s" % line)
+
+
+if __name__ == "__main__":
+    # Test Script
+    pass

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -59,6 +59,8 @@ class SondehubUploader(object):
         upload_timeout=20,
         upload_retries=5,
         user_callsign="N0CALL",
+        user_position=None,
+        user_antenna=""
     ):
         """ Initialise and start a Sondehub uploader
         
@@ -72,6 +74,8 @@ class SondehubUploader(object):
         self.upload_timeout = upload_timeout
         self.upload_retries = upload_retries
         self.user_callsign = user_callsign
+        self.user_position = user_position
+        self.user_antenna = user_antenna
 
         # Input Queue.
         self.input_queue = Queue()
@@ -91,7 +95,7 @@ class SondehubUploader(object):
 
         # Attempt to reformat the data.
         _telem = self.reformat_data(telemetry)
-        # self.log_debug("Telem: %s" % str(_telem))
+        self.log_debug("Telem: %s" % str(_telem))
 
         # Add it to the queue if we are running.
         if self.input_processing_running and _telem:
@@ -107,6 +111,8 @@ class SondehubUploader(object):
             "software_name": "radiosonde_auto_rx",
             "software_version": autorx.__version__,
             "uploader_callsign": self.user_callsign,
+            "uploader_position": self.user_position,
+            "uploader_antenna": self.user_antenna,
             "time_received": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%fZ")
         }
 
@@ -285,7 +291,7 @@ class SondehubUploader(object):
         _upload_success = False
 
         _start_time = time.time()
-        
+
         while _retries < self.upload_retries:
             # Run the request.
             try:

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -132,6 +132,11 @@ uploader_antenna = 1/4 wave monopole
 # then we may have to implement server-side rate-limiting to avoid affecting performance.
 upload_rate = 30
 
+# SondeHub Experimental DB
+# Enabled uploading of *all* telemetry to our experimental Elasticsearch database.
+# Eventually we hope to build a new mapping application based on this data!
+sondehub_enabled = True
+
 
 ########################
 # APRS UPLOAD SETTINGS #


### PR DESCRIPTION
This PR adds a new 'Sondehub DB' uploader. This is separate to the Habitat database, and *all* received telemetry is uploaded (gzip compressed to reduce upload size).

We hope to eventually enable better radiosonde telemetry access services via this new database.

For now, the upload rate and user position / antenna metadata is tied to the Habitat uploader settings. Eventually these will be separated, and we may move to a more real-time websockets based uploader. 