### PR TITLE
Version detection: Use Python 3 if available

### DIFF
--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -8,7 +8,7 @@
 # This can probably be done automatically.
 #AUTO_RX_VERSION="\"1.4.1-beta8\""
 
-AUTO_RX_VERSION="\"$(python -m autorx.version)\""
+AUTO_RX_VERSION="\"$(python3 -m autorx.version 2>/dev/null || python -m autorx.version)\""
 
 echo "Building for radiosonde_auto_rx version: $AUTO_RX_VERSION"
 


### PR DESCRIPTION
On Debian systems with only Python 3 installed, the `python` command is not available, and `python3` must be used instead.

This PR updates the logic to try `python3` first, and if not available, then fall back to trying `python`, which generally points at Python 2 if installed.