### PR TITLE
Container Updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    target-branch: "testing"

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,0 +1,50 @@
+name: Build Container Images
+
+on:
+  push:
+    branches:
+      - 'testing'
+    tags:
+      - 'v*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Calculate Container Metadata
+        id: meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/radiosonde_auto_rx
+          tag-semver: |
+            {{version}}
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildx-cache
+          key: buildx-cache-${{ github.sha }}
+          restore-keys: |
+            buildx-cache-
+
+      - name: Build and Push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/amd64, linux/386, linux/arm64, linux/arm/v6, linux/arm/v7
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache-new,mode=max
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Move Cache
+        run: |
+          rm -rf /tmp/buildx-cache
+          mv /tmp/buildx-cache-new /tmp/buildx-cache

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -35,7 +35,7 @@ jobs:
           restore-keys: |
             buildx-cache-
 
-      - name: Build and Push
+      - name: Build Images
         uses: docker/build-push-action@v2
         with:
           platforms: linux/amd64, linux/386, linux/arm64, linux/arm/v6, linux/arm/v7

--- a/auto_rx/requirements.txt
+++ b/auto_rx/requirements.txt
@@ -1,2 +1,7 @@
+crcmod
+python-dateutil
+flask
 flask-socketio==4.3.2
+numpy
+requests
 simplekml


### PR DESCRIPTION
1. Overhauls the `Dockerfile`.
2. Introduces a basic GItHub Actions Workflow to build Images for `amd64`, `386`, `arm64`, `armv6`, and `armv7` architectures. This will help identify changes within in the wider project that break the container build process.
3. Activates GitHub Dependabot for Actions Workflows so that PRs are automatically created when updates to the upstream Actions occur.

I am hoping to open another PR soon that expands this GitHub Actions Workflow so that it publishes these Container Images to a Container Registry automatically for consumption so that users do not have to `docker build` these themselves. I am near the finish on this, but wanted to split these out as two separate PRs.