### PR TITLE
Change HTML to show sondehub cards link once Radiosonde is "old"

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -247,7 +247,11 @@
                         // Add a link to HabHub if we have habitat enabled.
                         if ("habitat_enabled" in autorx_config){
                             if(autorx_config.habitat_enabled ==true){
-                                sonde_id_data.id = "<a href='http://sondehub.org/" + sonde_id + "' target='_blank'>" + sonde_id + "</a>";
+                                if (sonde_id_data.age != "old") {
+                                    sonde_id_data.id = sonde_id + " (<a href='http://sondehub.org/" + sonde_id + "' target='_blank'>live</a> - <a href='http://sondehub.org/card/" + sonde_id + "' target='_blank'>historical</a>)";
+                                } else {
+                                    sonde_id_data.id = sonde_id + " (<a href='http://sondehub.org/card/" + sonde_id + "' target='_blank'>historical</a>)";
+                                }     
                             }
                         }
 


### PR DESCRIPTION
I couldn't figure out how to modify the backend of the program to show historical records so I made this instead which shows the historical link once the radiosonde is "old" (determined by rx_timeout). It is useful if you have the webpage to save information for several days. 

![image](https://user-images.githubusercontent.com/22492406/112097170-a1a21580-8bf3-11eb-8941-922f24d9667d.png)
