### PR TITLE
Change Update Link if beta release

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -79,7 +79,11 @@
                     } else if (data.latest == "Unknown"){
                         //pass
                     } else {
-                        $("#footertext").html("Update Available: <a href='https://github.com/projecthorus/radiosonde_auto_rx/releases' target='_blank'>" + data.latest + "</a>");
+                        if (data.latest.includes("-beta")) {
+                            $("#footertext").html("Update Available: <a href='https://github.com/projecthorus/radiosonde_auto_rx/commits/testing' target='_blank'>" + data.latest + "</a>");
+                        } else {
+                            $("#footertext").html("Update Available: <a href='https://github.com/projecthorus/radiosonde_auto_rx/releases' target='_blank'>" + data.latest + "</a>");
+                        }
                     }
                   }
             });


### PR DESCRIPTION
This is a bit more of a personal preference change but I don't believe it negatively impacts anything.
I like to look at the changes with each testing beta version and as no changelog is provided I believe linking to the commit history is best.