### PR TITLE
Make following a radiosonde on the map buttery smooth

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -874,7 +874,7 @@
                 if (document.getElementById("sondeAutoFollow").checked == true){
                     // If we are currently following this sonde, snap the map to it.
                     if (msg.id == sonde_currently_following){
-                            mymap.panTo([msg.lat,msg.lon]);
+                            mymap.panTo([msg.lat,msg.lon], { duration: 1.2, easeLinearity: 0.9 });
                     }
                 }
             });


### PR DESCRIPTION
![Screen Recording 2021-04-30 at 10 18 43 547 2021-04-30 10_23_09](https://user-images.githubusercontent.com/234867/116633936-16f4c900-a99e-11eb-8600-436850347505.gif)

This changes the pan duration to just over 1 second which is the interval between most sonde frames and changes the panning to be more linear so that when following a sonde the movement feels smooth.