### PR TITLE
Hack around subpixel issue to make it less noticeable

### DIFF
--- a/auto_rx/autorx/static/css/main.css
+++ b/auto_rx/autorx/static/css/main.css
@@ -453,3 +453,9 @@ select[disabled]{
     font-size: 11px;
     font-weight: bold;
 }
+
+/* workaround for subpixel lines https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-688644225 */
+.leaflet-tile-container img {
+    width: 256.5px !important;
+    height: 256.5px !important;
+}


### PR DESCRIPTION
This is the workaround discussed in this leaflet issue to make the grid lines disappear on high DPI monitors. While it doesn't resolve the issue fully, it is MUCH better


https://github.com/Leaflet/Leaflet/issues/3575#issuecomment-688644225
**Before**
![Screen Shot 2021-04-30 at 11 13 23 362](https://user-images.githubusercontent.com/234867/116637004-0fd1b900-a9a6-11eb-89a8-f5c623685753.png)
**After**
![Screen Shot 2021-04-30 at 11 13 16 702](https://user-images.githubusercontent.com/234867/116637009-12341300-a9a6-11eb-8f3d-699d98da7656.png)
