### PR TITLE
Include libatomic1 in the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN case $(uname -m) in \
   apt-get update && \
   apt-get upgrade -y && \
   apt-get install -y \
+  libatomic1 \
   rng-tools \
   rtl-sdr \
   sox \


### PR DESCRIPTION
Useful for remote development. Only adds ~45kB to the image size.