### PR TITLE
Add starts of log archive endpoints, so web development can be started

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -722,6 +722,9 @@ def main():
         # Using print because logging may not be established yet
         print("Invalid logging path, using default. Does the folder exist?")
 
+    # Update Global logging path, used by other modules.
+    autorx.logging_path = logging_path
+
     # Configure logging
     _log_suffix = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S_system.log")
     _log_path = os.path.join(logging_path, _log_suffix)

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -49,3 +49,6 @@ task_list = {}
 scan_results = Queue()
 # Global scan inhibit flag, used by web interface.
 scan_inhibit = False
+
+# Logging Directory
+logging_path = "./log/"

--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+#
+#   radiosonde_auto_rx - Log File Utilities
+#
+#   Copyright (C) 2021  Mark Jessop <vk5qi@rfhead.net>
+#   Released under GNU GPL v3 or later
+#
+import autorx
+import datetime
+import glob
+import logging
+import os.path
+import time
+
+import numpy as np
+
+from dateutil.parser import parse
+from autorx.utils import short_type_lookup, readable_timedelta, strip_sonde_serial
+
+
+def log_filename_to_stats(filename):
+    """ Attempt to extract information about a log file from a supplied filename """
+    # Example log file name: 20210430-235413_IMET-89F2720A_IMET_401999_sonde.log
+    # ./log/20200320-063233_R2230624_RS41_402500_sonde.log
+
+    _basename = os.path.basename(filename)
+
+    _now_dt = datetime.datetime.now(datetime.timezone.utc)
+
+    try:
+        _fields = _basename.split("_")
+
+        # First field is the date/time the sonde was first received.
+        _date_str = _fields[0] + "Z"
+        _date_dt = parse(_date_str)
+
+        # Calculate age
+        _age_td = _now_dt - _date_dt
+        _time_delta = readable_timedelta(_age_td)
+
+        # Re-format date
+        _date_str2 = _date_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        # Second field is the serial number, which may include a sonde type prefix.
+        _serial = strip_sonde_serial(_fields[1])
+
+        # Third field is the sonde type, in 'shortform'
+        _type = _fields[2]
+        _type_str = short_type_lookup(_type)
+
+        # Fourth field is the sonde frequency in kHz
+        _freq = float(_fields[3])/1e3
+
+        return {
+            "datetime": _date_str2, 
+            "age": _time_delta,
+            "serial": _serial, 
+            "type": _type_str, 
+            "freq":_freq
+        }
+
+    except Exception as e:
+        logging.exception(f"Could not parse filename {_basename}", e)
+        return None
+
+    
+def list_log_files():
+    """ Look for all sonde log files within the logging directory """
+
+    # Output list, which will contain one object per log file, ordered by time
+    _output = []
+
+    # Search for file matching the expected log file name
+    _log_mask = os.path.join(autorx.logging_path, "*_sonde.log")
+    _log_files = glob.glob(_log_mask)
+
+    # Sort alphanumerically, which will result in the entries being date ordered
+    _log_files.sort()
+    # Flip array so newest is first.
+    _log_files.reverse()
+
+    for _file in _log_files:
+        _entry = log_filename_to_stats(_file)
+        if _entry:
+            _output.append(_entry)
+
+    return _output
+
+
+
+def read_log_file(filename):
+    """ Read in a log file """
+    return {}
+    
+
+
+def read_log_by_serial(serial):
+    """ Attempt to read in a log file for a particular sonde serial number """
+
+
+    # Search in the logging directory for a matching serial number
+    _log_mask = os.path.join(autorx.logging_path, f"*_{serial}_*_sonde.log")
+    _matching_files = glob.glob(_log_mask)
+    
+    # No matching entries found
+    if len(_matching_files) == 0:
+        return {}
+
+    return {}
+    
+
+
+if __name__ == "__main__":
+    import sys
+
+    print(list_log_files())
+
+    if len(sys.argv) > 1:
+        print(f"Attempting to read serial: {sys.argv[1]}")
+        print(read_log_by_serial(sys.argv[1]))

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -181,7 +181,10 @@ class SondehubUploader(object):
 
         elif telemetry["type"] == "LMS6":
             _output["manufacturer"] = "Lockheed Martin"
-            _output["type"] = "LMS6-400"
+            if "LMSX" in telemetry["id"]:
+                _output["type"] = "LMSX-400"
+            else:
+                _output["type"] = "LMS6-400"
             _output["serial"] = telemetry["id"].split("-")[1]
 
         elif telemetry["type"] == "MK2LMS":

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -155,6 +155,59 @@ def strip_sonde_serial(serial):
         return serial
 
 
+def short_type_lookup(type_name):
+    """ Lookup a short type name to a more descriptive name """
+
+    if type_name.startswith("RS41"):
+        if type_name == "RS41":
+            return "Vaisala RS41"
+        else:
+            return "Vaisala " + type_name
+    elif type_name.startswith("RS92"):
+        if type_name == "RS92":
+            return "Vaisala RS92"
+        else:
+            return "Vaisala " + type_name
+    elif type_name.startswith("DFM"):
+        return "Graw " + type_name
+    elif type_name.startswith("M10"):
+        return "Meteomodem M10"
+    elif type_name.startswith("M20"):
+        return "Meteomodem M20"
+    elif type_name == "LMS6":
+        return "Lockheed Martin LMS6-400"
+    elif type_name == "MK2LMS":
+        return "Lockheed Martin LMS6-1680"
+    elif type_name == "IMET":
+        return "Intermet Systems iMet-1/4"
+    elif type_name == "IMET5":
+        return "Intermet Systems iMet-54"
+    elif type_name == "MEISEI":
+        return "Meisei iMS-100/RS-11"
+    elif type_name == "MRZ":
+        return "Meteo-Radiy MRZ"
+    else:
+        return "Unknown"
+    
+
+def readable_timedelta(duration: timedelta):
+    """ 
+    Convert a timedelta into a readable string.
+    From: https://codereview.stackexchange.com/a/245215
+    """
+    data = {}
+    data['months'], remaining = divmod(duration.total_seconds(), 2_592_000)
+    data['days'], remaining = divmod(remaining, 86_400)
+    data['hours'], remaining = divmod(remaining, 3_600)
+    data['minutes'], _foo = divmod(remaining, 60)
+
+    time_parts = [f'{round(value)} {name}' for name, value in data.items() if value > 0]
+    if time_parts:
+        return ' '.join(time_parts)
+    else:
+        return 'below 1 second'
+
+
 class AsynchronousFileReader(threading.Thread):
     """ Asynchronous File Reader
     Helper class to implement asynchronous reading of a file

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -19,6 +19,7 @@ import autorx.config
 import autorx.scan
 from autorx.geometry import GenericTrack
 from autorx.utils import check_autorx_versions
+from autorx.log_files import list_log_files, read_log_by_serial
 from threading import Thread
 import flask
 from flask import request, abort
@@ -284,6 +285,16 @@ def shutdown_flask(shutdown_key):
 
     return ""
 
+@app.route("/get_log_list")
+def flask_get_log_list():
+    """ Return a list of log files, as a list of objects """
+    return json.dumps(list_log_files())
+
+
+@app.route("/get_log_by_serial/<serial>")
+def flask_get_log_by_serial(serial):
+    """ Request a log file be read, by serial number """
+    return json.dumps(read_log_by_serial(serial))
 
 #
 #   Control Endpoints.


### PR DESCRIPTION
Adds a /get_log_list endpoint, which returns a list (as JSON) of the form:
```
[{"datetime": "2021-05-09T00:48:17Z", "age": "1 hours 9 minutes", "serial": "S2510446", "type": "Vaisala RS41", "freq": 401.501}, {"datetime": "2021-05-08T23:02:31Z", "age": "2 hours 55 minutes", "serial": "S4631583", "type": "Vaisala RS41", "freq": 401.5}, {"datetime": "2021-05-08T11:07:25Z", "age": "14 hours 50 minutes", "serial": "S4631584", "type": "Vaisala RS41", "freq": 401.501}, {"datetime": "2021-05-08T00:58:36Z", "age": "1 days 59 minutes", "serial": "S2510449", "type": "Vaisala RS41", "freq": 401.5}, {"datetime": "2021-05-07T23:02:01Z", "age": "1 days 2 hours 56 minutes", "serial": "S4631619", "type": "Vaisala RS41", "freq": 401.5}, {"datetime": "2021-05-07T10:21:41Z", "age": "1 days 15 hours 36 minutes", "serial": "S4621278", "type": "Vaisala RS41", "freq": 401.5}]
```

This can be used to start prototyping a page which lists the log entries available for query.

Next up is to work on a query-by-serial endpoint (this will be `/get_log_by_serial/<serial>`) which reads in the specified serial number, does some data processing, and then passes the data onto the client.