### PR TITLE
Add option to export log files from web interface.

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -1568,6 +1568,13 @@
                   </div>                            
                   <br>
                   <br>
+                  <h2 style="display:inline;vertical-align:middle;">Export Logs</h2>
+                  &nbsp;
+                  <div style="display:inline;vertical-align:middle;">
+                    <button onclick="window.location.href='/export_logs'">EXPORT</button>
+                  </div>                 
+                  <br>
+                  <br>
                   <br>
             </div>       
         </div>    


### PR DESCRIPTION
Adds a button in the settings menu to export all files in the auto_rx log directory.
This allows a user to conveniently access telemetry and system logs with limited Linux / SSH knowledge.
Logs are added to a zip file and a time stamp is added to the filename when the request is processed.