### PR TITLE
Docker: Install all dependencies using pip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN apt-get update && \
     python3 \
     python3-dev \
     python3-pip \
-    python3-setuptools && \
+    python3-setuptools \
+    python3-wheel && \
   rm -rf /var/lib/apt/lists/*
 
 # Compile rtl-sdr from source.
@@ -34,7 +35,7 @@ COPY auto_rx/requirements.txt \
 
 # Install Python packages.
 RUN --mount=type=cache,target=/root/.cache/pip pip3 install \
-  --user --no-warn-script-location --no-binary numpy \
+  --user --no-warn-script-location --ignore-installed --no-binary numpy \
   -r /root/radiosonde_auto_rx/auto_rx/requirements.txt
 
 # Copy in radiosonde_auto_rx.


### PR DESCRIPTION
While this hasn't been a problem so far, to be safe we should use `--ignore-installed` to ensure that everything we need ends up in `/root/.local` ready to be copied over to the final container.

The risk if we don't is that a dependency of `python3-pip` will be used, but then not available in the final container.