### PR TITLE
Last Range column on historical view to accompany MinHeight

### DIFF
--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -91,6 +91,7 @@ def log_filename_to_stats(filename, quicklook=False):
                     _output["last"] = _quick["last"]
                     _output["has_snr"] = _quick["has_snr"]
                     _output["max_range"] = int(max(_output["first"]["range_km"],_output["last"]["range_km"]))
+                    _output["last_range"] = int(_output["last"]["range_km"])
                     _output["min_height"] = int(_output["last"]["alt"])
             except Exception as e:
                 logging.error(f"Could not quicklook file {filename}: {str(e)}")

--- a/auto_rx/autorx/templates/historical.html
+++ b/auto_rx/autorx/templates/historical.html
@@ -111,14 +111,18 @@
                         },
                         headerTooltip:"First Observed Date/Time"
                     },
-                    {title:"Type", field:"short_type", width:90, resizable:false},
-                    {title:"Serial", field:"serial", width:105, resizable:false},
-                    {title:"Count", field:"lines", width:75, resizable:false, headerTooltip:"Received Lines of Telemetry"},
+                    {title:"Type", field:"short_type", width:85, resizable:false},
+                    {title:"Serial", field:"serial", width:95, resizable:false},
+                    {title:"Count", field:"lines", width:72, resizable:false, headerTooltip:"Received Lines of Telemetry"},
                     {title:"Last H", field:"min_height", width:75, resizable:false, headerTooltip:"Last Observed Height (m)",
                         formatter:function(cell, formatterParams, onRendered){
                             return cell.getValue() + " m"; //return the contents of the cell;
                         }},
-                    {title:"Max R", field:"max_range", width:75, resizable:false, headerTooltip:"Maximum Observed Range (km))",
+                    {title:"Last R", field:"last_range", width:75, resizable:false, headerTooltip:"Last Observed Range (km)",
+                        formatter:function(cell, formatterParams, onRendered){
+                            return cell.getValue() + " km"; //return the contents of the cell;
+                        }},
+                    {title:"Max R", field:"max_range", width:73, resizable:false, headerTooltip:"Maximum Observed Range (km))",
                         formatter:function(cell, formatterParams, onRendered){
                             return cell.getValue() + " km"; //return the contents of the cell;
                         }},


### PR DESCRIPTION
The historical view shows the minimal height (Min H) of the last signal received from the sonde during descending.
Accompanying the last range (Last R) it gives valuable information on the receipt coverage of the ground station.
This combination proofed to help improve the ground station (antenna) tuning and increases the landing accuracy reported on websites like sondehub.org, radiosondy.info, and APRS.

Tested this with logging information from several months.