### PR TITLE
Alert on newer, not different

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -17,7 +17,7 @@ except ImportError:
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.5.5"
+__version__ = "1.5.6-beta1"
 
 
 # Global Variables

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -110,7 +110,7 @@ def check_autorx_versions(current_version=auto_rx_version):
         # User is on a testing branch version.
         # Compare against the testing branch version - when a release is made, the testing
         # branch will have the same version as the main branch, then will advance.
-        if semver.compare(_testing_branch_version, current_version):
+        if semver.compare(_testing_branch_version, current_version) == 1:
             # Newer testing version available.
             return _testing_branch_version
         else:
@@ -118,7 +118,7 @@ def check_autorx_versions(current_version=auto_rx_version):
             return "Latest"
     else:
         # User is running the main branch
-        if semver.compare(_main_branch_version, current_version):
+        if semver.compare(_main_branch_version, current_version) == 1:
             return _main_branch_version
         else:
             return "Latest"
@@ -299,18 +299,18 @@ def generate_aprs_id(sonde_data):
         else:
             # Unknown sonde type, don't know how to handle this yet.
             _object_name = None
-        
+
         # Pad or clip to 9 characters
         if len(_object_name) > 9:
             _object_name = _object_name[:9]
         elif len(_object_name) < 9:
             _object_name = _object_name + " " * (9 - len(_object_name))
-        
+
         return _object_name
 
 
 def readable_timedelta(duration: timedelta):
-    """ 
+    """
     Convert a timedelta into a readable string.
     From: https://codereview.stackexchange.com/a/245215
     """


### PR DESCRIPTION
Instead of checking `semver.compare` is `True`, which simply indicates if the versions are different, we should be checking that `semver.compare` is `1`, which indicates that the version we are comparing against is newer than the local version.

This is mainly to prevent messages indicating a newer version is available when running a release candidate.