### PR TITLE
Docker: Use Debian Bullseye as the base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------
 # The build container
 # -------------------
-FROM debian:buster-slim AS build
+FROM debian:bullseye-slim AS build
 
 # Upgrade base packages.
 RUN apt-get update && \
@@ -48,7 +48,7 @@ RUN /bin/sh build.sh
 # -------------------------
 # The application container
 # -------------------------
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 EXPOSE 5000/tcp
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 EXPOSE 5000/tcp
 


### PR DESCRIPTION
Debian 11 (Bullseye) has been released now, so updating the container images to use this as the base.

Some initial local testing has so far went well, but figured it would be good to get this in `testing` early on in the 1.5.6 development cycle so we can put it through its paces more before releasing 1.5.6.