### PR TITLE
Flush stdout only

### DIFF
--- a/utils/fsk_demod.c
+++ b/utils/fsk_demod.c
@@ -6,7 +6,7 @@
 
   C test driver for fsk_demod in fsk.c. Reads in a stream of 32 bit cpu endian
   floats and writes out the detected bits
-   
+
 
 \*---------------------------------------------------------------------------*/
 
@@ -76,7 +76,7 @@ int main(int argc,char *argv[]){
     int nsym = FSK_DEFAULT_NSYM;
     int mask = 0;
     int tx_tone_separation = 100;
-    
+
     int o = 0;
     int opt_idx = 0;
     while( o != -1 ){
@@ -94,9 +94,9 @@ int main(int argc,char *argv[]){
             {"mask",      required_argument,  0, 'm'},
             {0, 0, 0, 0}
         };
-        
+
         o = getopt_long(argc,argv,"fhlp:cdt::sb:u:m",long_opts,&opt_idx);
-        
+
         switch(o){
         case 'c':
             complex_input = 2;
@@ -152,12 +152,12 @@ int main(int argc,char *argv[]){
         }
     }
     int dx = optind;
-    
+
     if( (argc - dx) < 5){
         fprintf(stderr, "Too few arguments\n");
         goto helpmsg;
     }
-    
+
     if( (argc - dx) > 5) {
         fprintf(stderr, "Too many arguments\n");
     helpmsg:
@@ -180,24 +180,24 @@ int main(int argc,char *argv[]){
         fprintf(stderr," --mask TxFreqSpace Use \"mask\" freq estimator (default is \"peak\" estimator)\n");
         exit(1);
     }
-    
+
     /* Extract parameters */
     M = atoi(argv[dx]);
     Fs = atoi(argv[dx + 1]);
     Rs = atoi(argv[dx + 2]);
-    
+
     if( (M!=2) && (M!=4) ){
         fprintf(stderr,"Mode %d is not valid. Mode must be 2 or 4.\n",M);
         goto helpmsg;
     }
-    
+
     /* Open files */
     if(strcmp(argv[dx + 3],"-")==0){
         fin = stdin;
     }else{
         fin = fopen(argv[dx + 3],"r");
     }
-    
+
     if(strcmp(argv[dx + 4],"-")==0){
         fout = stdout;
     }else{
@@ -222,22 +222,22 @@ int main(int argc,char *argv[]){
     fsk_set_freq_est_limits(fsk,fsk_lower,fsk_upper);
 
     fsk_set_freq_est_alg(fsk, mask);
-    
+
     if(fin==NULL || fout==NULL || fsk==NULL){
         fprintf(stderr,"Couldn't open files\n");
         exit(1);
     }
 
     /* set up testframe mode */
-         
+
     int      testframecnt, bitcnt, biterr, testframe_detected;
     uint8_t *bitbuf_tx = NULL, *bitbuf_rx = NULL;
     if (testframe_mode) {
         bitbuf_tx = (uint8_t*)malloc(sizeof(uint8_t)*TEST_FRAME_SIZE); assert(bitbuf_tx != NULL);
         bitbuf_rx = (uint8_t*)malloc(sizeof(uint8_t)*TEST_FRAME_SIZE); assert(bitbuf_rx != NULL);
-    
+
         /* Generate known tx frame from known seed */
-        
+
         srand(158324);
         for(i=0; i<TEST_FRAME_SIZE; i++){
             bitbuf_tx[i] = rand()&0x1;
@@ -248,13 +248,13 @@ int main(int argc,char *argv[]){
         bitcnt = 0;
         biterr = 0;
     }
-    
+
     if(enable_stats){
         loop_time = ((float)fsk_nin(fsk))/((float)Fs);
         stats_loop = (int)(1/(stats_rate*loop_time));
         stats_ctr = 0;
     }
-    
+
     /* allocate buffers for processing */
     if(soft_dec_mode){
         sdbuf = (float*)malloc(sizeof(float)*fsk->Nbits); assert(sdbuf != NULL);
@@ -265,13 +265,13 @@ int main(int argc,char *argv[]){
     modbuf = (COMP*)malloc(sizeof(COMP)*(fsk->N+fsk->Ts*2));
 
     /* set up signal handler so we can terminate gracefully */
-    
+
     if (signal(SIGTERM, sig_handler) == SIG_ERR) {
         printf("\ncan't catch SIGTERM\n");
     }
-    
+
     /* Demodulate! */
-    
+
     while( fread(rawbuf,bytes_per_sample*complex_input,fsk_nin(fsk),fin) == fsk_nin(fsk) ){
         /* convert input to a buffer of floats.  Note scaling isn't really necessary for FSK */
 
@@ -297,7 +297,7 @@ int main(int argc,char *argv[]){
                     modbuf[i].real = ((float)rawbuf[2*i])/FDMDV_SCALE;
                     modbuf[i].imag = ((float)rawbuf[2*i+1]/FDMDV_SCALE);
                 }
-            }            
+            }
         }
 
         if(soft_dec_mode){
@@ -305,7 +305,7 @@ int main(int argc,char *argv[]){
         }else{
             fsk_demod(fsk,bitbuf,modbuf);
         }
-        
+
         testframe_detected = 0;
         if (testframe_mode) {
             /* attempt to find a testframe and update stats */
@@ -332,7 +332,7 @@ int main(int argc,char *argv[]){
                         errs++;
                     }
                 }
-                
+
                 if (errs < 0.1*TEST_FRAME_SIZE) {
                     /* OK, we have a valid test frame sync, so lets count errors */
                     testframe_detected = 1;
@@ -346,7 +346,7 @@ int main(int argc,char *argv[]){
                 }
             }
         } /* if (testframe_mode) ... */
-        
+
         if (enable_stats) {
             if ((stats_ctr < 0) || testframe_detected) {
                 fsk_get_demod_stats(fsk,&stats);
@@ -369,11 +369,11 @@ int main(int argc,char *argv[]){
                 if(fsk->mode == 4){
                     fprintf(stderr,", \"f3_est\":%.1f, \"f4_est\":%.1f",f_est[2],f_est[3]);
                 }
-	    
+
                 if (testframe_mode == 0) {
                     /* Print the eye diagram */
 
-                    fprintf(stderr,",\t\"eye_diagram\":[");                 
+                    fprintf(stderr,",\t\"eye_diagram\":[");
                     for(i=0;i<stats.neyetr;i++){
                         fprintf(stderr,"[");
                         for(j=0;j<stats.neyesamp;j++){
@@ -384,7 +384,7 @@ int main(int argc,char *argv[]){
                         if(i<stats.neyetr-1) fprintf(stderr,",");
                     }
                     fprintf(stderr,"],");
-	    
+
                     /* Print a sample of the FFT from the freq estimator */
                     fprintf(stderr,"\"samp_fft\":[");
                     Ndft = fsk->Ndft/2;
@@ -394,12 +394,12 @@ int main(int argc,char *argv[]){
                     }
                     fprintf(stderr,"]");
                 }
-                
+
                 if (testframe_mode) {
                     fprintf(stderr,", \"frames\":%d, \"bits\":%d, \"errs\":%d",testframecnt,bitcnt,biterr);
                 }
-                
-                fprintf(stderr,"}\n");                
+
+                fprintf(stderr,"}\n");
 
                 if (stats_ctr < 0) {
                     stats_ctr = stats_loop;
@@ -416,30 +416,26 @@ int main(int argc,char *argv[]){
             fwrite(bitbuf,sizeof(uint8_t),fsk->Nbits,fout);
         }
 
-        if(fin == stdin || fout == stdin){
-            fflush(fin);
-            fflush(fout);
-        }
+        if (fout == stdout) fflush(stdout);
     } /* while(fread ...... */
 
     if (testframe_mode) {
         free(bitbuf_tx);
         free(bitbuf_rx);
     }
-    
+
     if(soft_dec_mode){
         free(sdbuf);
     }else{
         free(bitbuf);
     }
-    
+
     free(rawbuf);
     free(modbuf);
-    
+
     fclose(fin);
     fclose(fout);
     fsk_destroy(fsk);
 
     return 0;
 }
-


### PR DESCRIPTION
Doing a `fflush` on `stdin` was preventing `fsk_demod` from functioning on Alpine Linux, which uses musl libc (https://wiki.musl-libc.org/functional-differences-from-glibc.html).

My understanding is that `fflush` is generally used for clearing the output stream, and when used on input streams is only really usable for seekable files, so in most cases is ineffective when used with `stdin`.  I'm not sure what the purpose of flushing `stdin` was here?

Also noticed it was alternatively checking for `fout == stdin`, which in theory should never be the case.

In my limited testing this fixed the issues I experienced on Alpine Linux with no obvious negative impact to glibc environments, though I lack context as to why it was the way it was, so may be missing something.

/cc @drowe67