### PR TITLE
Revert "Use debian bullseye as the base"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # -------------------
 # The build container
 # -------------------
-FROM debian:bullseye-slim AS build
+FROM debian:buster-slim AS build
 
 # Upgrade base packages.
 RUN apt-get update && \
@@ -48,7 +48,7 @@ RUN /bin/sh build.sh
 # -------------------------
 # The application container
 # -------------------------
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 EXPOSE 5000/tcp
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM debian:bullseye-slim
+FROM debian:buster-slim
 
 EXPOSE 5000/tcp
 


### PR DESCRIPTION
Reverts projecthorus/radiosonde_auto_rx#562

Received a report of https://github.com/moby/moby/issues/40734 suddenly being triggered by the move from Buster to Bullseye. Reverting for now until I can figure out what is going on.