### PR TITLE
Custom nearby landing email subject

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -819,6 +819,7 @@ def main():
             mail_from=config["email_from"],
             mail_to=config["email_to"],
             mail_subject=config["email_subject"],
+            mail_nearby_landing_subject=config["email_nearby_landing_subject"],
             station_position=(
                 config["station_lat"],
                 config["station_lon"],

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -206,7 +206,6 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 auto_rx_config["email_from"] = config.get("email", "from")
                 auto_rx_config["email_to"] = config.get("email", "to")
                 auto_rx_config["email_subject"] = config.get("email", "subject")
-                auto_rx_config["email_nearby_landing_subject"] = config.get("email", "nearby_landing_subject")
 
                 if auto_rx_config["email_smtp_authentication"] not in [
                     "None",

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -70,6 +70,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         "email_from": "sonde@localhost",
         "email_to": None,
         "email_subject": "<type> Sonde launch detected on <freq>: <id>",
+        "email_nearby_landing_subject": "Nearby Radiosonde Landing Detected - <id>",
         # SDR Settings
         "sdr_fm": "rtl_fm",
         "sdr_power": "rtl_power",
@@ -651,6 +652,16 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 "Config - Did not find lms6-1680_experimental setting, using default (disabled)"
             )
             auto_rx_config["experimental_decoders"]["MK2LMS"] = False
+
+        try:
+            auto_rx_config["email_nearby_landing_subject"] = config.get(
+                "email", "nearby_landing_subject"
+            )
+        except:
+            logging.warning(
+                "Config - Did not find email_nearby_landing_subject setting, using default"
+            )
+            auto_rx_config["email_nearby_landing_subject"] = "Nearby Radiosonde Landing Detected - <id>"
 
         # If we are being called as part of a unit test, just return the config now.
         if no_sdr_test:

--- a/auto_rx/autorx/email_notification.py
+++ b/auto_rx/autorx/email_notification.py
@@ -46,6 +46,7 @@ class EmailNotification(object):
         mail_from=None,
         mail_to=None,
         mail_subject=None,
+        mail_nearby_landing_subject=None,
         station_position=None,
         launch_notifications=True,
         landing_notifications=True,
@@ -62,6 +63,7 @@ class EmailNotification(object):
         self.mail_from = mail_from
         self.mail_to = mail_to
         self.mail_subject = mail_subject
+        self.mail_nearby_landing_subject = mail_nearby_landing_subject 
         self.station_position = station_position
         self.launch_notifications = launch_notifications
         self.landing_notifications = landing_notifications
@@ -266,7 +268,11 @@ class EmailNotification(object):
                                 % strip_sonde_serial(_id)
                             )
 
-                            _subject = "Nearby Radiosonde Landing Detected - %s" % _id
+                            # Construct subject
+                            _subject = self.mail_nearby_landing_subject
+                            _subject = _subject.replace("<id>", _id)
+                            _subject = _subject.replace("<type>", telemetry["type"])
+                            _subject = _subject.replace("<freq>", telemetry["freq"])
 
                             self.send_notification_email(subject=_subject, message=msg)
 
@@ -401,6 +407,7 @@ if __name__ == "__main__":
         mail_from=config["email_from"],
         mail_to=config["email_to"],
         mail_subject=config["email_subject"],
+        mail_nearby_landing_subject=config["email_nearby_landing_subject"],
         station_position=(-10.0, 10.0, 0.0,),
         landing_notifications=True,
         launch_notifications=True,

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -320,6 +320,12 @@ to = someone@example.com
 # <id> - Sonde Serial Number (i.e. M1234567)
 subject = <type> Sonde launch detected on <freq>: <id>
 
+# Custom nearby landing subject field. The following fields can be included:
+# <freq> - Sonde Frequency, i.e. 401.520 MHz
+# <type> - Sonde Type (RS94/RS41)
+# <id> - Sonde Serial Number (i.e. M1234567)
+nearby_landing_subject = Nearby Radiosonde Landing Detected - <id>
+
 
 ###################
 # ROTATOR CONTROL #


### PR DESCRIPTION
Useful for those who own more stations, they can add station name to nearby_landing_subject field in station.cfg