### PR TITLE
[systemd service] use of environment variables

### DIFF
--- a/auto_rx/auto_rx.service
+++ b/auto_rx/auto_rx.service
@@ -3,10 +3,10 @@ Description=auto_rx
 After=syslog.target
 
 [Service]
-ExecStart=/usr/bin/python3 /home/pi/radiosonde_auto_rx/auto_rx/auto_rx.py -t 0
+ExecStart=/usr/bin/python3 $HOME/radiosonde_auto_rx/auto_rx/auto_rx.py -t 0
 Restart=always
 RestartSec=120
-WorkingDirectory=/home/pi/radiosonde_auto_rx/auto_rx/
+WorkingDirectory=$HOME/radiosonde_auto_rx/auto_rx/
 User=pi
 SyslogIdentifier=auto_rx
 


### PR DESCRIPTION
Hello there!
Is it possible to replace the annoying `/home/pi` by something like `$HOME` or `/home/$(whoami)` so that it matches any user home folder?