### PR TITLE
add sed for systemd service

### DIFF
--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -82,4 +82,7 @@ cp ../demod/mod/meisei100mod .
 cp ../demod/mod/imet54mod .
 cp ../demod/mod/mp3h1mod .
 
+# Match user name in systemd service: no more need to use a text editor
+sed -i "s/pi/$(whoami)/g" auto_rx.service
+
 echo "Done!"


### PR DESCRIPTION
Added sed so that the username is *automatically set* in `auto_rx.service`
Admitting the script is run by the right user (not as root)
I just tested and it worked fine for me