### PR TITLE
Fix/aprs performance

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -876,7 +876,6 @@ def main():
             position_report=config["aprs_position_report"],
             aprsis_host=config["aprs_server"],
             aprsis_port=config["aprs_port"],
-            synchronous_upload_time=config["aprs_upload_rate"],
             callsign_validity_threshold=config["payload_id_valid"],
             station_beacon=config["station_beacon_enabled"],
             station_beacon_rate=config["station_beacon_rate"],

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -36,7 +36,7 @@ except ImportError:
 # Fixed minimum update rates for APRS & Habitat
 # These are set to avoid congestion on the APRS-IS network, and on the Habitat server
 # Please respect other users of these networks and leave these settings as they are.
-MINIMUM_APRS_UPDATE_RATE = 30
+MINIMUM_APRS_UPDATE_RATE = 60
 MINIMUM_HABITAT_UPDATE_RATE = 30
 
 

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -176,7 +176,7 @@ aprs_pass = 00000
 # This has a lower limit of 30 seconds, to avoid flooding the APRS-IS network.
 # Please be respectful of other uses of the APRS-IS network, and do not attempt
 # to upload faster than this. 
-upload_rate = 30
+upload_rate = 60
 
 # APRS-IS server to upload to.
 # Default to radiosondy.info for now, to allow stats to show up on http://radiosondy.info


### PR DESCRIPTION
Changes min APRS time to 60 seconds. Removes version from APRS comment. Removes wall clock.

<img width="1590" alt="image" src="https://user-images.githubusercontent.com/234867/156056199-60e1d5a4-8647-426c-8f18-0bb035e055ff.png">

Does this look right to you @hessu ? 

Closes: 
- #619
- #618


