### PR TITLE
Add a task preference item to each SDR

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -92,6 +92,20 @@ gpsd_adaptor = None
 # This contains frequncies that should be blocked for a short amount of time.
 temporary_block_list = {}
 
+def get_sdr_item_pref(sdr_item):
+    """A helper function for the purpose of sorting the list of SDR by preference.
+
+    Args:
+        sdr_item (tuple) : Single element resulting from sdr_list.items(). A pair of ID (str) and config (dict).
+
+    Returns:
+        (tuple) : A pair with the scanner preference value inverted and ID, for the purpose of sorting by highest
+                  values first and if equal then lowest to highest ID.
+    """
+    id = sdr_item[0]
+    cfg = sdr_item[1]
+    return (-cfg["preference"], id)
+
 
 def allocate_sdr(check_only=False, task_description=""):
     """Allocate an un-used SDR for a task.
@@ -102,8 +116,8 @@ def allocate_sdr(check_only=False, task_description=""):
     Returns:
         (str): The device index/serial number of the free/allocated SDR, if one is free, else None.
     """
-
-    for _idx in sorted(autorx.sdr_list.keys()):
+    
+    for _idx in [key for key, val in sorted(autorx.sdr_list.items(), key=get_sdr_item_pref)]:
         if autorx.sdr_list[_idx]["in_use"] == False:
             # Found a free SDR!
             if check_only:

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -699,6 +699,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 _ppm = round(config.getfloat(_section, "ppm"))
                 _gain = config.getfloat(_section, "gain")
                 _bias = config.getboolean(_section, "bias")
+                _preference = config.getint(_section, "preference", fallback=0)
 
                 if (auto_rx_config["sdr_quantity"] > 1) and (_device_idx == "0"):
                     logging.critical(
@@ -713,6 +714,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                         "ppm": _ppm,
                         "gain": _gain,
                         "bias": _bias,
+                        "preference": _preference,
                         "in_use": False,
                         "task": None,
                     }

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -43,6 +43,12 @@ gain = -1
 # Bias Tee - Enable the bias tee in the RTLSDR v3 Dongles.
 bias = False
 
+# Preference (integer)
+#   By default all the SDR's have preference of 0 for allocation of scanner and decode tasks.
+#   Apply an higher value to the SDRs preferred
+#   Use a negative value to avoid using them.
+preference = 1
+
 [sdr_2]
 # As above, for the next SDR, if used. Note the warning about serial numbers.
 device_idx = 00000002


### PR DESCRIPTION
The default behavior is kept if station.cfg isn't updated
By default the SDR's are tasked simply from the lowest to the higher id (serial number)
Sometimes due to different RTL hardware, antennas or RF filtering/amplification is convenient to sort the task allocation based on a defined order.
This changes add an optional parameter to each SDR that can be used to raise or lower his allocation preference.

Hope this will help other people from the community

Python code changes by my son Diogo (I'm a C/C++ guy)

Regards CT7ABP Pedro.