### PR TITLE
Simplified distance formula

### DIFF
--- a/auto_rx/utils/receiver_stats.py
+++ b/auto_rx/utils/receiver_stats.py
@@ -77,8 +77,8 @@ def position_info(listener, balloon):
     eb = sin(angle_at_centre) * tb
     elevation = atan2(ea, eb)
 
-    # Use cosine rule to find unknown side.
-    distance = sqrt((ta ** 2) + (tb ** 2) - 2 * tb * ta * cos(angle_at_centre))
+    # Use pythagorean theorem to find unknown side.
+    distance = sqrt((ea ** 2) + (eb ** 2))
 
     # Give a bearing in range 0 <= b < 2pi
     if bearing < 0:


### PR DESCRIPTION
I was reading through the logic that calculates the distance and elevation because I was curious about whether it properly treated the earth as spherical. Happily, it does.

However, I noticed that the distance calculation was excessively complex. Simple algebra shows that my formula is the same.

We have: 
```
ea = (cos(angle_at_centre) * tb) - ta
eb = sin(angle_at_centre) * tb
```
Therefore if we square each one:
```
ea**2 = cos(angle_at_centre)**2 * tb**2 + ta**2 - 2*cos(angle_at_centre)*tb*ta
eb**2 = sin(angle_at_centre)**2 * tb**2
```
Add them together and factor out the tb**2 term at the start of each:
```
ea**2 + eb**2 = tb**2 * (cos(angle_at_centre)**2 + sin(angle_at_centre)**2) + ta**2 - 2*cos(angle_at_centre)*tb*ta
```
Of course a basic trigonometric identity is that summing the square of the sine and square of the cosine of an angle comes to 1, so we can remove that.
```
ea**2 + eb**2 = tb**2 + ta**2 - 2*cos(angle_at_centre)*tb*ta
```
Now, compare to the original line in the code:
```
    distance = sqrt((ta ** 2) + (tb ** 2) - 2 * tb * ta * cos(angle_at_centre))
```
These match, aside from rearranging terms. The fact we've already found ea and eb means the code can be made cleaner by pulling this line down to a simple application of the Pythagorean Theorem.