### PR TITLE
Allow compiler selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
 AUTO_RX_VERSION := $(shell PYTHONPATH=./auto_rx python -m autorx.version)
 
+# Uncomment to use clang as a compiler.
+#CC = clang
+#export CC
+
 CFLAGS = -O3 -w -Wno-unused-variable -DVER_JSN_STR=\"$(AUTO_RX_VERSION)\"
 export CFLAGS
 


### PR DESCRIPTION
I have measured the `fsk_demod` and with clang 11 and gcc 10 the clang is ~15% faster