### PR TITLE
Makefile: add build dependencies for header files

### DIFF
--- a/demod/mod/Makefile
+++ b/demod/mod/Makefile
@@ -24,7 +24,10 @@ imet54mod: imet54mod.o demod_mod.o
 
 mp3h1mod: mp3h1mod.o demod_mod.o
 
-demod_mod.o : CFLAGS += -Ofast
+bch_ecc_mod.o: bch_ecc_mod.h
+
+demod_mod.o: CFLAGS += -Ofast
+demod_mod.o: demod_mod.h
 
 clean:
 	$(RM) $(PROGRAMS) $(PROGRAMS:=.o) demod_mod.o bch_ecc_mod.o

--- a/utils/Makefile
+++ b/utils/Makefile
@@ -6,5 +6,7 @@ all: $(PROGRAMS)
 
 fsk_demod: fsk_demod.o fsk.o modem_stats.o kiss_fftr.o kiss_fft.o
 
+kiss_fft.o: kiss_fft.c _kiss_fft_guts.h kiss_fft.h
+
 clean:
 	$(RM) $(PROGRAMS) $(PROGRAMS:=.o) fsk.o modem_stats.o kiss_fftr.o kiss_fft.o


### PR DESCRIPTION
The dependencies were added manually. This can be automated with some more advanced `Makefile` magic, but I'm not sure it's worth the complexity in such a simple case.