### PR TITLE
Show more decimals for low elevation angles

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -666,7 +666,11 @@
                             var _look_angles = calculate_lookangles(_station, _bal);
 
                             sonde_id_data.azimuth = _look_angles.azimuth.toFixed(1);
-                            sonde_id_data.elevation = _look_angles.elevation.toFixed(1);
+		            if (sonde_id_data.elevation >= 10){
+                                sonde_id_data.elevation = _look_angles.elevation.toFixed(1);
+			    }else{
+                                sonde_id_data.elevation = _look_angles.elevation.toFixed(2);
+			    }
                             sonde_id_data.range = (_look_angles.range/1000).toFixed(1);
                         } else{
                             // Insert blank data.


### PR DESCRIPTION
For low elevation angles (eg 0.9°) the second decimal place rally matters, with only one the occuracy is rapidly decreasing.