### PR TITLE
Replace import * by importing only required objects

### DIFF
--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -20,9 +20,9 @@ from threading import Thread
 from types import FunctionType, MethodType
 from .utils import AsynchronousFileReader, rtlsdr_test, position_info, generate_aprs_id
 from .gps import get_ephemeris, get_almanac
-from .sonde_specific import *
+from .sonde_specific import fix_datetime, imet_unique_id
 from .fsk_demod import FSKDemodStats
-from .sdr_wrappers import *
+from .sdr_wrappers import test_sdr, get_sdr_iq_cmd, get_sdr_fm_cmd
 
 # Global valid sonde types list.
 VALID_SONDE_TYPES = [

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -23,7 +23,7 @@ from .utils import (
     reset_all_rtlsdrs,
     peak_decimation,
 )
-from .sdr_wrappers import *
+from .sdr_wrappers import test_sdr, reset_sdr, get_sdr_name, get_sdr_iq_cmd, get_sdr_fm_cmd, get_power_spectrum
 
 
 try:

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -17,7 +17,7 @@ import argparse
 import glob
 import os
 import fastkml
-from dateutil.parser import *
+from dateutil.parser import parse
 from shapely.geometry import Point, LineString
 
 def read_telemetry_csv(filename,


### PR DESCRIPTION
The * imports also all other objects imported by the module, which easily leads to a mess and hard to find issues, especially during development.