### PR TITLE
Add simple-websocket to requirements

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.6.2-beta1"
+__version__ = "1.6.2-beta2"
 
 
 # Global Variables

--- a/auto_rx/requirements.txt
+++ b/auto_rx/requirements.txt
@@ -6,3 +6,4 @@ numpy
 requests
 semver
 simplekml
+simple-websocket


### PR DESCRIPTION
This should remove those pesky "The WebSocket transport is not available" messages...