### PR TITLE
Landing notification tweaks, allow localhost APRS

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.6.2-beta2"
+__version__ = "1.6.2-beta3"
 
 
 # Global Variables

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -683,7 +683,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         # that this goes against the wishes of the radiosonde_auto_rx developers to not be part
         # of the bigger problem of APRS-IS congestion. 
 
-        ALLOWED_APRS_SERVERS = ["radiosondy.info"]
+        ALLOWED_APRS_SERVERS = ["radiosondy.info", "localhost"]
         ALLOWED_APRS_PORTS = [14590]
 
         if auto_rx_config["aprs_server"] not in ALLOWED_APRS_SERVERS:


### PR DESCRIPTION
Only send landing notifications if sonde has gone above the landing alt threshold first.
Allow APRS-IS to localhost.