### PR TITLE
Prototype: Run readsb during scan downtime

### DIFF
--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -526,8 +526,8 @@ min_distance = 1000
 scan_dwell_time = 20
 # Scanner - Detection Dwell time - How long to wait for a sonde detection on each peak.
 detect_dwell_time = 5
-# Scanner - Delay between scans. We should delay a short amount between scans to allow for decoders and other actions to jump in.
-scan_delay = 10
+# Scanner - Delay between scans. We should delay between scans to allow for decoders and other actions to jump in. ADSB is received during the downtime.
+scan_delay = 60
 # Quantize search results to x Hz steps. Useful as most sondes are on 10 kHz frequency steps.
 quantization = 10000
 # Decoder Spacing Limit - Only start a new decoder if it is separated from an existing decoder by at least


### PR DESCRIPTION
I would like my SDR to track radiosondes as a priority, but receive other interesting things during the downtime - most obviously, contribute ADSB data.

This PR isn't a serious proposal on how to implement that, obviously (though it does work as a minimal PoC...). I'd like to use it more as a discussion ground, whether this kind of functionality would be welcome by you.

Thoughts:

- Would a generalized configuration "pair of commands for post-scan hook, pre-scan hook" configuration be a viable approach, for example?
- I'd ideally like to have readsb just have an API to pause its SDR usage rather than starting/stopping it completely (which is noisy on the logs). I might try to contribute that API, but I didn't discuss it with upstream yet. Probably independent on this PR.
- BTW independent of this proposal (I noticed it when changing the sleep code) - the sleep of scan_delay always completes to full even if the other thread is just half a second too slow to signal thread stop - this introduces a long delay until actual decoding begins. Is this intentional?