### PR TITLE
Add iq_dec to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ auto_rx/dfm09mod
 auto_rx/dft_detect
 auto_rx/fsk_demod
 auto_rx/imet1rs_dft
+auto_rx/iq_dec
 auto_rx/lms6Xmod
 auto_rx/lms6mod
 auto_rx/m10mod


### PR DESCRIPTION
#735 added a new program (`iq_dec`) but did not add the executable to to the `.gitignore` file. I've done that here, which should prevent git from reporting it as an untracked file.