### PR TITLE
Use fixed-point notation for ascent rate

### DIFF
--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -194,7 +194,7 @@ def flask_get_kml_feed():
             Altitude: {alt:.1f} m
             Heading: {heading:.1f} degrees
             Ground Speed: {vel_h:.2f} m/s
-            Ascent Rate: {vel_v:.2} m/s
+            Ascent Rate: {vel_v:.2f} m/s
             Temperature: {temp:.1f} C
             Humidity: {humidity:.1f} %
             Pressure: {pressure:.1f} hPa


### PR DESCRIPTION
In the KML feed, Ascent Rate is currently displayed in scientific notation, which is difficult to read:

![Screenshot from 2023-08-01 09-30-09](https://github.com/projecthorus/radiosonde_auto_rx/assets/583749/e6b96cf2-db31-4acf-92eb-3d4e2ca5c05c)

Here I've changed it to fixed-point to match the other fields:

![Screenshot from 2023-08-01 09-49-48](https://github.com/projecthorus/radiosonde_auto_rx/assets/583749/bb5fb328-a883-4b82-aa6a-e1536b374be8)
