### PR TITLE
Update email_notification.py

### DIFF
--- a/auto_rx/autorx/email_notification.py
+++ b/auto_rx/autorx/email_notification.py
@@ -498,7 +498,7 @@ if __name__ == "__main__":
         "frame": 10,
         "lat": -10.01,
         "lon": 10.01,
-        "alt": 800,
+        "alt": 1006,
         "temp": 1.0,
         "type": "RS41",
         "freq": "401.520 MHz",


### PR DESCRIPTION
Change initial altitude in the landing notification test to be compatible with the new requirement that the sonde exceeds 1000' before being eligible for a landing notification.