### PR TITLE
Restart always_on decoders after 6 hours of no packets. Give addition…

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -244,7 +244,7 @@ def start_decoder(freq, sonde_type, continuous=False):
             _exp_sonde_type = sonde_type
 
         if continuous:
-            _timeout = 0
+            _timeout = 3600*6 # 6 hours before a 'continuous' decoder gets restarted automatically.
         else:
             _timeout = config["rx_timeout"]
 

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.7.1"
+__version__ = "1.7.2-beta1"
 
 
 # Global Variables

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -71,7 +71,7 @@ def test_sdr(
             f"{ss_iq_path} "
             f"-f {check_freq} "
             f"-s 48000 "
-            f"-r {sdr_hostname} -q {sdr_port} -n 48000 - > /dev/null 2> /dev/null"
+            f"-r {sdr_hostname} -q {sdr_port} -n 48000 - > /dev/null"
         )
 
         logging.debug(f"SpyServer - Testing using command: {_cmd}")
@@ -85,6 +85,12 @@ def test_sdr(
             logging.critical(
                 f"SpyServer ({sdr_hostname}:{sdr_port}) - ss_iq call failed with return code {e.returncode}."
             )
+            # Look at the error output in a bit more details.
+            _output = e.output.decode("ascii")
+            if "outside currently allowed range" in _output:
+                logging.critical(
+                    f"SpyServer ({sdr_hostname}:{sdr_port}) - SpyServer does not cover required frequency {check_freq}, please check your SpyServer configuration!"
+                )
             return False
 
         return True


### PR DESCRIPTION
…al error messages if spyserver configured incorrectly.