### PR TITLE
Combine export_selected and export_all

### DIFF
--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -335,48 +335,18 @@ def flask_get_log_by_serial_detail():
         return json.dumps(read_log_by_serial(_serial, skewt_decimation=_decim))
 
 
+@app.route("/export_all_log_files")
 @app.route("/export_log_files/<serialb64>")
-def flask_export_selected_log_files(serialb64):
+def flask_export_log_files(serialb64=None):
     """ 
     Zip and download a set of log files.
     The list of log files is provided in the URL as a base64-encoded JSON list.
     """
 
     try:
-        _serial_list = json.loads(base64.b64decode(serialb64))
+        _serial_list = json.loads(base64.b64decode(serialb64)) if serialb64 else None
 
         _zip = zip_log_files(_serial_list)
-
-        _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")
-
-        response = make_response(
-            flask.send_file(
-                _zip,
-                mimetype="application/zip",
-                as_attachment=True,
-                download_name=f"autorx_logfiles_{autorx.config.global_config['habitat_uploader_callsign']}_{_ts}.zip",
-            )
-        )
-
-        # Add header asking client not to cache the download
-        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
-        response.headers["Pragma"] = "no-cache"
-
-        return response
-
-    except Exception as e:
-        logging.error("Web - Error handling Zip request:" + str(e))
-        abort(400)
-
-
-@app.route("/export_all_log_files")
-def flask_export_all_log_files():
-    """ 
-    Zip and download all log files. This may take some time.
-    """
-
-    try:
-        _zip = zip_log_files()
 
         _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")
 


### PR DESCRIPTION
While looking at web.py, I noticed that `flask_export_selected_log_files` and `flask_export_all_log_files` are almost identical. By combining them, some code duplication can be avoided.