### PR TITLE
Generate KML files from the "Historical" page

### DIFF
--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -14,6 +14,7 @@ import logging
 import os.path
 import time
 import zipfile
+import xml.etree.ElementTree as ET
 
 import numpy as np
 
@@ -519,6 +520,129 @@ def zip_log_files(serial_list=None):
 
     # Return the BytesIO object
     return data
+
+
+def _coordinates_to_kml_placemark(lat, lon, alt,
+                                  name="Placemark Name",
+                                  absolute=False,
+                                  icon="http://maps.google.com/mapfiles/kml/shapes/placemark_circle.png",
+                                  scale=1.0):
+    """ Generate a generic placemark object """
+
+    placemark = ET.Element("Placemark")
+
+    pm_name = ET.SubElement(placemark, "name")
+    pm_name.text = name
+
+    style = ET.SubElement(placemark, "Style")
+    icon_style = ET.SubElement(style, "IconStyle")
+    icon_scale = ET.SubElement(icon_style, "scale")
+    icon_scale.text = str(scale)
+    pm_icon = ET.SubElement(icon_style, "Icon")
+    href = ET.SubElement(pm_icon, "href")
+    href.text = icon
+
+    point = ET.SubElement(placemark, "Point")
+    if absolute:
+        altitude_mode = ET.SubElement(point, "altitudeMode")
+        altitude_mode.text = "absolute"
+    coordinates = ET.SubElement(point, "coordinates")
+    coordinates.text = f"{lon:.6f},{lat:.6f},{alt:.6f}"
+
+    return placemark
+
+
+def _flight_path_to_kml_placemark(flight_path,
+                                  name="Flight Path Name",
+                                  track_color="aaffffff",
+                                  poly_color="20000000",
+                                  track_width=2.0,
+                                  absolute=True,
+                                  extrude=True):
+    ''' Produce a placemark object from a flight path array '''
+
+    placemark = ET.Element("Placemark")
+
+    pm_name = ET.SubElement(placemark, "name")
+    pm_name.text = name
+
+    style = ET.SubElement(placemark, "Style")
+    line_style = ET.SubElement(style, "LineStyle")
+    color = ET.SubElement(line_style, "color")
+    color.text = track_color
+    width = ET.SubElement(line_style, "width")
+    width.text = str(track_width)
+    poly_style = ET.SubElement(style, "PolyStyle")
+    color = ET.SubElement(poly_style, "color")
+    color.text = poly_color
+    fill = ET.SubElement(poly_style, "fill")
+    fill.text = "1"
+    outline = ET.SubElement(poly_style, "outline")
+    outline.text = "1"
+
+    line_string = ET.SubElement(placemark, "LineString")
+    if absolute:
+        if extrude:
+            ls_extrude = ET.SubElement(line_string, "extrude")
+            ls_extrude.text = "1"
+        altitude_mode = ET.SubElement(line_string, "altitudeMode")
+        altitude_mode.text = "absolute"
+    else:
+        ls_tessellate = ET.SubElement(line_string, "tessellate")
+        ls_tessellate.text = "1"
+    coordinates = ET.SubElement(line_string, "coordinates")
+    coordinates.text = " ".join(f"{lon:.6f},{lat:.6f},{alt:.6f}" for lat, lon, alt in flight_path)
+
+    return placemark
+
+
+def _log_file_to_kml_folder(filename, absolute=True, extrude=True, last_only=False):
+    ''' Convert a single sonde log file to a KML Folder object '''
+
+    # Read file.
+    _flight_data = read_log_file(filename)
+
+    _flight_serial = _flight_data["serial"]
+    _launch_time = parse(_flight_data["first_time"]).strftime("%Y%m%d-%H%M%SZ")
+    # Generate a comment line to use in the folder and placemark descriptions
+    _track_comment = "%s %s" % (_launch_time, _flight_serial)
+    _landing_comment = "%s Last Position" % (_flight_serial)
+
+    # Grab last-seen position
+    _landing_pos = _flight_data["path"][-1]
+
+    _folder = ET.Element("Folder")
+    _name = ET.SubElement(_folder, "name")
+    _name.text = _track_comment
+    _description = ET.SubElement(_folder, "description")
+    _description.text = "Radiosonde Flight Path"
+
+    # Generate the placemark & flight track.
+    if not last_only:
+        _folder.append(_flight_path_to_kml_placemark(_flight_data["path"], name=_track_comment,
+                                                     absolute=absolute, extrude=extrude))
+    _folder.append(_coordinates_to_kml_placemark(_landing_pos[0], _landing_pos[1], _landing_pos[2],
+                                                 name=_landing_comment, absolute=absolute))
+
+    return _folder
+
+
+def log_files_to_kml(file_list, kml_file, absolute=True, extrude=True, last_only=False):
+    """ Convert a collection of log files to a KML file """
+
+    kml_root = ET.Element("kml", {"xmlns": "http://www.opengis.net/kml/2.2"})
+    kml_doc = ET.SubElement(kml_root, "Document")
+
+    for file in file_list:
+        print("Processing: %s" % file)
+        try:
+            kml_doc.append(_log_file_to_kml_folder(file, absolute=absolute,
+                                                   extrude=extrude, last_only=last_only))
+        except:
+            print("Failed to process: %s" % file)
+
+    tree = ET.ElementTree(kml_root)
+    tree.write(kml_file, encoding="UTF-8", xml_declaration=True)
 
 
 if __name__ == "__main__":

--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -634,12 +634,12 @@ def log_files_to_kml(file_list, kml_file, absolute=True, extrude=True, last_only
     kml_doc = ET.SubElement(kml_root, "Document")
 
     for file in file_list:
-        print("Processing: %s" % file)
+        logging.debug(f"Converting {file} to KML")
         try:
             kml_doc.append(_log_file_to_kml_folder(file, absolute=absolute,
                                                    extrude=extrude, last_only=last_only))
-        except:
-            print("Failed to process: %s" % file)
+        except Exception:
+            logging.exception(f"Failed to convert {file} to KML")
 
     tree = ET.ElementTree(kml_root)
     tree.write(kml_file, encoding="UTF-8", xml_declaration=True)

--- a/auto_rx/autorx/templates/historical.html
+++ b/auto_rx/autorx/templates/historical.html
@@ -181,6 +181,7 @@
                 $("#showsonde-skew").prop('disabled', true);
                 $("#hidesonde-skew").prop('disabled', true);
                 $("#download-logs").prop('disabled', true);
+                $("#generate-kml").prop('disabled', true);
             }
 
             async function enableMenu () {
@@ -194,6 +195,7 @@
                 $("#showsonde-skew").prop('disabled', false);
                 $("#hidesonde-skew").prop('disabled', false);
                 $("#download-logs").prop('disabled', false);
+                $("#generate-kml").prop('disabled', false);
             }
 
             if ((window.innerWidth/window.innerHeight) < 1) {
@@ -975,6 +977,41 @@
                 downloadLogs();
             });
             
+            function generateKML() {
+                // Generate a KML file from a set of log files.
+                selectedrows = table.getSelectedData();
+                if (selectedrows.length > 0) {
+                    // Create the list of log files.
+                    _serial_list = [];
+                    for (let i = 0; i < selectedrows.length; i++){
+                        _serial_list.push(selectedrows[i]['serial']);
+                    }
+
+                    if(_serial_list.length>50){
+                        if (confirm("Warning - downloading lots of log may take some time. Are you sure?")) {
+                            // Just continue on.
+                        } else {
+                            return;
+                        }
+                    }
+
+                    if(_serial_list.length == table.getData().length){
+                        // Request all log files
+                        window.open("generate_kml" , '_blank');
+                    }else {
+                        // Just request the selected ones.
+                        // Convert the list to JSON, and then to base64
+                        b64 = btoa(JSON.stringify(_serial_list));
+                        // Make the request in a new tab
+                        window.open("generate_kml/"+b64 , '_blank');
+                    }
+                }
+            }
+
+            $("#generate-kml").click(function(){
+                generateKML();
+            });
+
             // List of available map layers.
             var Mapnik = L.tileLayer.provider("OpenStreetMap.Mapnik", {edgeBufferTiles: 2});
             var DarkMatter = L.tileLayer.provider("CartoDB.DarkMatter", {edgeBufferTiles: 2});
@@ -1472,6 +1509,7 @@
                 <button id="showsonde-coverage" style="margin:3px auto">Plot Coverage</button>
                 <button id="showsonde-skew" style="margin:3px auto">Plot Skew-T</button>
                 <button id="download-logs" style="margin:3px auto">Download Logs</button>
+                <button id="generate-kml" style="margin:3px auto">Generate KML</button>
             </div>
             <br>
             </div>

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -8,8 +8,11 @@
 import base64
 import copy
 import datetime
+import glob
+import io
 import json
 import logging
+import os
 import random
 import requests
 import time
@@ -22,6 +25,7 @@ from autorx.geometry import GenericTrack
 from autorx.utils import check_autorx_versions
 from autorx.log_files import list_log_files, read_log_by_serial, zip_log_files
 from autorx.decode import SondeDecoder
+from utils.log_to_kml import convert_single_file, write_kml
 from queue import Queue
 from threading import Thread
 import flask
@@ -367,6 +371,62 @@ def flask_export_log_files(serialb64=None):
 
     except Exception as e:
         logging.error("Web - Error handling Zip request:" + str(e))
+        abort(400)
+
+
+@app.route("/generate_kml")
+@app.route("/generate_kml/<serialb64>")
+def flask_generate_kml(serialb64=None):
+    """ 
+    Generate a KML file from a set of log files.
+    The list of log files is provided in the URL as a base64-encoded JSON list.
+    """
+
+    try:
+        if serialb64:
+            _serial_list = json.loads(base64.b64decode(serialb64))
+            _log_files = []
+            for _serial in _serial_list:
+                _log_mask = os.path.join(autorx.logging_path, f"*_*{_serial}_*_sonde.log")
+                _matching_files = glob.glob(_log_mask)
+
+                if len(_matching_files) >= 1:
+                    _log_files.append(_matching_files[0])
+        else:
+            _log_mask = os.path.join(autorx.logging_path, "*_sonde.log")
+            _log_files = glob.glob(_log_mask)
+
+        _placemarks = []
+
+        for _file in _log_files:
+            try:
+                _placemarks.append(convert_single_file(_file, absolute=True, extrude=True, last_only=False))
+            except:
+                pass
+
+        _kml_file = io.BytesIO()
+        write_kml(_placemarks, _kml_file)
+        _kml_file.seek(0)
+
+        _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")
+
+        response = make_response(
+            flask.send_file(
+                _kml_file,
+                mimetype="application/vnd.google-earth.kml+xml",
+                as_attachment=True,
+                download_name=f"autorx_logfiles_{autorx.config.global_config['habitat_uploader_callsign']}_{_ts}.kml",
+            )
+        )
+
+        # Add header asking client not to cache the download
+        response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
+        response.headers["Pragma"] = "no-cache"
+
+        return response
+
+    except Exception as e:
+        logging.error("Web - Error handling KML request:" + str(e))
         abort(400)
 
 #

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -23,9 +23,8 @@ import autorx.config
 import autorx.scan
 from autorx.geometry import GenericTrack
 from autorx.utils import check_autorx_versions
-from autorx.log_files import list_log_files, read_log_by_serial, zip_log_files
+from autorx.log_files import list_log_files, read_log_by_serial, zip_log_files, log_files_to_kml
 from autorx.decode import SondeDecoder
-from utils.log_to_kml import convert_single_file, write_kml
 from queue import Queue
 from threading import Thread
 import flask
@@ -396,16 +395,8 @@ def flask_generate_kml(serialb64=None):
             _log_mask = os.path.join(autorx.logging_path, "*_sonde.log")
             _log_files = glob.glob(_log_mask)
 
-        _placemarks = []
-
-        for _file in _log_files:
-            try:
-                _placemarks.append(convert_single_file(_file, absolute=True, extrude=True, last_only=False))
-            except:
-                pass
-
         _kml_file = io.BytesIO()
-        write_kml(_placemarks, _kml_file)
+        log_files_to_kml(_log_files, _kml_file)
         _kml_file.seek(0)
 
         _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -9,13 +9,9 @@
 # sudo pip install fastkml shapely
 #
 
-import sys
-import time
-import datetime
 import traceback
 import argparse
 import glob
-import os
 import fastkml
 from dateutil.parser import parse
 from shapely.geometry import Point, LineString

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -67,23 +67,6 @@ def read_telemetry_csv(filename,
     return output
 
 
-def flight_burst_position(flight_path):
-    ''' Search through flight data for the burst position and return it. '''
-
-    # Read through array and hunt for max altitude point.
-    current_alt = 0.0
-    current_index = 0
-    for i in range(len(flight_path)):
-        if flight_path[i][3] > current_alt:
-            current_alt = flight_path[i][3]
-            current_index = i
-
-    return flight_path[current_index]
-
-
-ns = '{http://www.opengis.net/kml/2.2}'
-
-
 def new_placemark(lat, lon, alt,
                   name="Placemark Name",
                   absolute=False,
@@ -190,8 +173,7 @@ def convert_single_file(filename, absolute=True, extrude=True, last_only=False):
     _track_comment = "%s %s" % (_launch_time, _flight_serial)
     _landing_comment = "%s Last Position" % (_flight_serial)
 
-    # Grab burst and last-seen positions
-    _burst_pos = flight_burst_position(_flight_data)
+    # Grab last-seen position
     _landing_pos = _flight_data[-1]
 
     _folder = ET.Element("Folder")

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -20,13 +20,14 @@ import fastkml
 from dateutil.parser import parse
 from shapely.geometry import Point, LineString
 
+
 def read_telemetry_csv(filename,
-    datetime_field = 0,
-    latitude_field = 3,
-    longitude_field = 4,
-    altitude_field = 5,
-    delimiter=','):
-    ''' 
+                       datetime_field=0,
+                       latitude_field=3,
+                       longitude_field=4,
+                       altitude_field=5,
+                       delimiter=','):
+    '''
     Read in a radiosonde_auto_rx generated telemetry CSV file.
     Fields to use can be set as arguments to this function.
     These have output like the following:
@@ -47,7 +48,7 @@ def read_telemetry_csv(filename,
 
     output = []
 
-    f = open(filename,'r')
+    f = open(filename, 'r')
 
     for line in f:
         try:
@@ -90,12 +91,13 @@ def flight_burst_position(flight_path):
 
 ns = '{http://www.opengis.net/kml/2.2}'
 
+
 def new_placemark(lat, lon, alt,
-    placemark_id="Placemark ID",
-    name="Placemark Name",
-    absolute = False,
-    icon = "http://maps.google.com/mapfiles/kml/shapes/placemark_circle.png",
-    scale = 1.0):
+                  placemark_id="Placemark ID",
+                  name="Placemark Name",
+                  absolute=False,
+                  icon="http://maps.google.com/mapfiles/kml/shapes/placemark_circle.png",
+                  scale=1.0):
     """ Generate a generic placemark object """
 
     if absolute:
@@ -104,8 +106,8 @@ def new_placemark(lat, lon, alt,
         _alt_mode = 'clampToGround'
 
     flight_icon_style = fastkml.styles.IconStyle(
-        ns=ns, 
-        icon_href=icon, 
+        ns=ns,
+        icon_href=icon,
         scale=scale)
 
     flight_style = fastkml.styles.Style(
@@ -113,7 +115,7 @@ def new_placemark(lat, lon, alt,
         styles=[flight_icon_style])
 
     flight_placemark = fastkml.kml.Placemark(
-        ns=ns, 
+        ns=ns,
         id=placemark_id,
         name=name,
         description="",
@@ -127,16 +129,15 @@ def new_placemark(lat, lon, alt,
     return flight_placemark
 
 
-
 def flight_path_to_geometry(flight_path,
-    placemark_id="Flight Path ID",
-    name="Flight Path Name",
-    track_color="aaffffff",
-    poly_color="20000000",
-    track_width=2.0,
-    absolute = True,
-    extrude = True,
-    tessellate = True):
+                            placemark_id="Flight Path ID",
+                            name="Flight Path Name",
+                            track_color="aaffffff",
+                            poly_color="20000000",
+                            track_width=2.0,
+                            absolute=True,
+                            extrude=True,
+                            tessellate=True):
     ''' Produce a fastkml geometry object from a flight path array '''
 
     # Handle selection of absolute altitude mode
@@ -149,7 +150,7 @@ def flight_path_to_geometry(flight_path,
     track_points = []
     for _point in flight_path:
         # Flight path array is in lat,lon,alt order, needs to be in lon,lat,alt
-        track_points.append([_point[2],_point[1],_point[3]])
+        track_points.append([_point[2], _point[1], _point[3]])
 
     _flight_geom = LineString(track_points)
 
@@ -186,8 +187,8 @@ def flight_path_to_geometry(flight_path,
 
 
 def write_kml(geom_objects,
-                filename="output.kml",
-                comment=""):
+              filename="output.kml",
+              comment=""):
     """ Write out flight path geometry objects to a kml file. """
 
     kml_root = fastkml.kml.KML()
@@ -201,7 +202,7 @@ def write_kml(geom_objects,
     for _flight in geom_objects:
         kml_doc.append(_flight)
 
-    with open(filename,'w') as kml_file:
+    with open(filename, 'w') as kml_file:
         kml_file.write(kml_doc.to_string())
         kml_file.close()
 
@@ -214,7 +215,7 @@ def convert_single_file(filename, absolute=True, tessellate=True, last_only=Fals
 
     # Extract the flight's serial number and launch time from the first line in the file.
     _first_line = _flight_data[0][4]
-    _flight_serial = _first_line.split(',')[1] # Serial number is the second field in the line.
+    _flight_serial = _first_line.split(',')[1]  # Serial number is the second field in the line.
     _launch_time = _flight_data[0][0].strftime("%Y%m%d-%H%M%SZ")
     # Generate a comment line to use in the folder and placemark descriptions
     _track_comment = "%s %s" % (_launch_time, _flight_serial)
@@ -225,11 +226,13 @@ def convert_single_file(filename, absolute=True, tessellate=True, last_only=Fals
     _landing_pos = _flight_data[-1]
 
     # Generate the placemark & flight track.
-    _flight_geom = flight_path_to_geometry(_flight_data, name=_track_comment, absolute=absolute, tessellate=tessellate, extrude=tessellate)
-    _landing_geom = new_placemark(_landing_pos[1], _landing_pos[2], _landing_pos[3], name=_landing_comment, absolute=absolute)
+    _flight_geom = flight_path_to_geometry(_flight_data, name=_track_comment, absolute=absolute,
+                                           tessellate=tessellate, extrude=tessellate)
+    _landing_geom = new_placemark(_landing_pos[1], _landing_pos[2], _landing_pos[3],
+                                  name=_landing_comment, absolute=absolute)
 
     _folder = fastkml.kml.Folder(ns, _flight_serial, _track_comment, 'Radiosonde Flight Path')
-    if last_only == False:
+    if not last_only:
         _folder.append(_flight_geom)
     _folder.append(_landing_geom)
 
@@ -238,12 +241,17 @@ def convert_single_file(filename, absolute=True, tessellate=True, last_only=Fals
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--input", type=str, default="../log/*_sonde.log", 
-        help="Path to log file. May include wildcards, though the path must be wrapped in quotes. Default=../log/*_sonde.log")
-    parser.add_argument("-o", "--output", type=str, default="sondes.kml", help="KML output file name. Default=sondes.kml")
-    parser.add_argument('--clamp', action="store_false", default=True, help="Clamp tracks to ground instead of showing absolute altitudes.")
-    parser.add_argument('--noextrude', action="store_false", default=True, help="Disable Extrusions for absolute flight paths.")
-    parser.add_argument('--lastonly', action="store_true", default=False, help="Only plot last-seen sonde positions, not the flight paths.")
+    parser.add_argument("-i", "--input", type=str, default="../log/*_sonde.log",
+                        help="Path to log file. May include wildcards, though the path "
+                             "must be wrapped in quotes. Default=../log/*_sonde.log")
+    parser.add_argument("-o", "--output", type=str, default="sondes.kml",
+                        help="KML output file name. Default=sondes.kml")
+    parser.add_argument('--clamp', action="store_false", default=True,
+                        help="Clamp tracks to ground instead of showing absolute altitudes.")
+    parser.add_argument('--noextrude', action="store_false", default=True,
+                        help="Disable Extrusions for absolute flight paths.")
+    parser.add_argument('--lastonly', action="store_true", default=False,
+                        help="Only plot last-seen sonde positions, not the flight paths.")
     args = parser.parse_args()
 
     _file_list = glob.glob(args.input)
@@ -253,27 +261,11 @@ if __name__ == "__main__":
     for _file in _file_list:
         print("Processing: %s" % _file)
         try:
-            _placemarks.append(convert_single_file(_file, absolute=args.clamp, tessellate=args.noextrude, last_only=args.lastonly))
+            _placemarks.append(convert_single_file(_file, absolute=args.clamp,
+                                                   tessellate=args.noextrude, last_only=args.lastonly))
         except:
             print("Failed to process: %s" % _file)
 
     write_kml(_placemarks, filename=args.output)
 
     print("Output saved to: %s" % args.output)
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -9,136 +9,11 @@
 import argparse
 import glob
 import sys
-import xml.etree.ElementTree as ET
-from dateutil.parser import parse
 from os.path import dirname, abspath
 
 parent_dir = dirname(dirname(abspath(__file__)))
 sys.path.append(parent_dir)
-from autorx.log_files import read_log_file
-
-
-def new_placemark(lat, lon, alt,
-                  name="Placemark Name",
-                  absolute=False,
-                  icon="http://maps.google.com/mapfiles/kml/shapes/placemark_circle.png",
-                  scale=1.0):
-    """ Generate a generic placemark object """
-
-    placemark = ET.Element("Placemark")
-
-    pm_name = ET.SubElement(placemark, "name")
-    pm_name.text = name
-
-    style = ET.SubElement(placemark, "Style")
-    icon_style = ET.SubElement(style, "IconStyle")
-    icon_scale = ET.SubElement(icon_style, "scale")
-    icon_scale.text = str(scale)
-    pm_icon = ET.SubElement(icon_style, "Icon")
-    href = ET.SubElement(pm_icon, "href")
-    href.text = icon
-
-    point = ET.SubElement(placemark, "Point")
-    if absolute:
-        altitude_mode = ET.SubElement(point, "altitudeMode")
-        altitude_mode.text = "absolute"
-    coordinates = ET.SubElement(point, "coordinates")
-    coordinates.text = f"{lon:.6f},{lat:.6f},{alt:.6f}"
-
-    return placemark
-
-
-def flight_path_to_geometry(flight_path,
-                            name="Flight Path Name",
-                            track_color="aaffffff",
-                            poly_color="20000000",
-                            track_width=2.0,
-                            absolute=True,
-                            extrude=True):
-    ''' Produce a placemark object from a flight path array '''
-
-    placemark = ET.Element("Placemark")
-
-    pm_name = ET.SubElement(placemark, "name")
-    pm_name.text = name
-
-    style = ET.SubElement(placemark, "Style")
-    line_style = ET.SubElement(style, "LineStyle")
-    color = ET.SubElement(line_style, "color")
-    color.text = track_color
-    width = ET.SubElement(line_style, "width")
-    width.text = str(track_width)
-    poly_style = ET.SubElement(style, "PolyStyle")
-    color = ET.SubElement(poly_style, "color")
-    color.text = poly_color
-    fill = ET.SubElement(poly_style, "fill")
-    fill.text = "1"
-    outline = ET.SubElement(poly_style, "outline")
-    outline.text = "1"
-
-    line_string = ET.SubElement(placemark, "LineString")
-    if absolute:
-        if extrude:
-            ls_extrude = ET.SubElement(line_string, "extrude")
-            ls_extrude.text = "1"
-        altitude_mode = ET.SubElement(line_string, "altitudeMode")
-        altitude_mode.text = "absolute"
-    else:
-        ls_tessellate = ET.SubElement(line_string, "tessellate")
-        ls_tessellate.text = "1"
-    coordinates = ET.SubElement(line_string, "coordinates")
-    coordinates.text = " ".join(f"{lon:.6f},{lat:.6f},{alt:.6f}" for lat, lon, alt in flight_path)
-
-    return placemark
-
-
-def write_kml(geom_objects,
-              kml_file,
-              comment=""):
-    """ Write out flight path geometry objects to a kml file. """
-
-    kml_root = ET.Element("kml", {"xmlns": "http://www.opengis.net/kml/2.2"})
-    kml_doc = ET.SubElement(kml_root, "Document")
-
-    if type(geom_objects) is not list:
-        geom_objects = [geom_objects]
-
-    for _flight in geom_objects:
-        kml_doc.append(_flight)
-
-    tree = ET.ElementTree(kml_root)
-    tree.write(kml_file, encoding="UTF-8", xml_declaration=True)
-
-
-def convert_single_file(filename, absolute=True, extrude=True, last_only=False):
-    ''' Convert a single sonde log file to a KML Folder object '''
-
-    # Read file.
-    _flight_data = read_log_file(filename)
-
-    _flight_serial = _flight_data["serial"]
-    _launch_time = parse(_flight_data["first_time"]).strftime("%Y%m%d-%H%M%SZ")
-    # Generate a comment line to use in the folder and placemark descriptions
-    _track_comment = "%s %s" % (_launch_time, _flight_serial)
-    _landing_comment = "%s Last Position" % (_flight_serial)
-
-    # Grab last-seen position
-    _landing_pos = _flight_data["path"][-1]
-
-    _folder = ET.Element("Folder")
-    _name = ET.SubElement(_folder, "name")
-    _name.text = _track_comment
-    _description = ET.SubElement(_folder, "description")
-    _description.text = "Radiosonde Flight Path"
-
-    # Generate the placemark & flight track.
-    if not last_only:
-        _folder.append(flight_path_to_geometry(_flight_data["path"], name=_track_comment,
-                                               absolute=absolute, extrude=extrude))
-    _folder.append(new_placemark(_landing_pos[0], _landing_pos[1], _landing_pos[2],
-                                 name=_landing_comment, absolute=absolute))
-
-    return _folder
+from autorx.log_files import log_files_to_kml
 
 
 if __name__ == "__main__":
@@ -158,17 +33,8 @@ if __name__ == "__main__":
 
     _file_list = glob.glob(args.input)
 
-    _placemarks = []
-
-    for _file in _file_list:
-        print("Processing: %s" % _file)
-        try:
-            _placemarks.append(convert_single_file(_file, absolute=args.clamp,
-                                                   extrude=args.noextrude, last_only=args.lastonly))
-        except:
-            print("Failed to process: %s" % _file)
-
     with open(args.output, "wb") as kml_file:
-        write_kml(_placemarks, kml_file)
+        log_files_to_kml(_file_list, kml_file, absolute=args.clamp,
+                         extrude=args.noextrude, last_only=args.lastonly)
 
     print("Output saved to: %s" % args.output)


### PR DESCRIPTION
Log files can be converted to KML using the `log_to_kml` command-line utility. To make the process simpler, I've added a "Generate KML" button to the "Historical" page:

![Screenshot from 2024-01-29 17-13-23](https://github.com/projecthorus/radiosonde_auto_rx/assets/583749/06afba67-260a-4eaf-89b4-129ba9a13d16)

When clicked, a KML file is generated from the selected log files.

To avoid making `fastkml` and `shapely` dependencies of auto_rx, I rewrote `log_to_kml` to generate KML using the standard library's built-in XML support. (It should be possible to eliminate auto_rx's `simplekml` dependency in the same way, but I'll leave that to another pull request.)