### PR TITLE
Generate live KML using ElementTree

### DIFF
--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -564,7 +564,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
             logging.warning(
                 "Config - Did not find kml_refresh_rate setting, using default (10 seconds)."
             )
-            auto_rx_config["kml_refresh_rate"] = 11
+            auto_rx_config["kml_refresh_rate"] = 10
 
         # New Sondehub db Settings
         try:

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -411,6 +411,7 @@ def flask_generate_kml(serialb64=None):
             _log_files = glob.glob(_log_mask)
 
         _kml_file = io.BytesIO()
+        _log_files.sort(reverse=True)
         log_files_to_kml(_log_files, _kml_file)
         _kml_file.seek(0)
 

--- a/auto_rx/requirements.txt
+++ b/auto_rx/requirements.txt
@@ -5,5 +5,4 @@ flask-socketio
 numpy
 requests
 semver
-simplekml
 simple-websocket

--- a/auto_rx/utils/log_to_kml.py
+++ b/auto_rx/utils/log_to_kml.py
@@ -32,6 +32,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     _file_list = glob.glob(args.input)
+    _file_list.sort(reverse=True)
 
     with open(args.output, "wb") as kml_file:
         log_files_to_kml(_file_list, kml_file, absolute=args.clamp,


### PR DESCRIPTION
Here I've switched live KML generation over to Python's built-in `ElementTree`, which allows it to share a lot of code with the `log_to_kml` utility and eliminates the dependency on `simplekml`. I also modified the output of `log_to_kml` a bit to make it more like live KML, which I think makes it a bit nicer to work with.