### PR TITLE
Replace deprecated utcnow() with now()

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -787,7 +787,7 @@ def main():
     autorx.logging_path = logging_path
 
     # Configure logging
-    _log_suffix = datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S_system.log")
+    _log_suffix = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S_system.log")
     _log_path = os.path.join(logging_path, _log_suffix)
 
     system_log_enabled = False

--- a/auto_rx/autorx/aprs.py
+++ b/auto_rx/autorx/aprs.py
@@ -214,7 +214,7 @@ def generate_station_object(
     _datum = "!w%s%s!" % (_lat_prec, _lon_prec)
 
     # Generate timestamp using current UTC time
-    _aprs_timestamp = datetime.datetime.utcnow().strftime("%H%M%S")
+    _aprs_timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%H%M%S")
 
     # Add version string to position comment, if requested.
     _aprs_comment = comment
@@ -807,10 +807,10 @@ if __name__ == "__main__":
     # ['frame', 'id', 'datetime', 'lat', 'lon', 'alt', 'temp', 'type', 'freq', 'freq_float', 'datetime_dt']
     test_telem = [
         # These types of DFM serial IDs are deprecated
-        # {'id':'DFM06-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.utcnow()},
-        # {'id':'DFM09-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.utcnow()},
-        # {'id':'DFM15-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.utcnow()},
-        # {'id':'DFM17-12345678', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.utcnow()},
+        # {'id':'DFM06-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.now(datetime.timezone.utc)},
+        # {'id':'DFM09-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.now(datetime.timezone.utc)},
+        # {'id':'DFM15-123456', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.now(datetime.timezone.utc)},
+        # {'id':'DFM17-12345678', 'frame':10, 'lat':-10.0, 'lon':10.0, 'alt':10000, 'temp':1.0, 'type':'DFM', 'freq':'401.520 MHz', 'freq_float':401.52, 'heading':0.0, 'vel_h':5.1, 'vel_v':-5.0, 'datetime_dt':datetime.datetime.now(datetime.timezone.utc)},
         {
             "id": "DFM-19123456",
             "frame": 10,
@@ -827,7 +827,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
         },
         {
             "id": "DFM-123456",
@@ -845,7 +845,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
         },
         {
             "id": "N1234567",
@@ -863,7 +863,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
         },
         {
             "id": "M1234567",
@@ -881,7 +881,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
         },
     ]
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -220,7 +220,7 @@ class SondeDecoder(object):
 
         # Raw hex filename
         if self.save_raw_hex:
-            _outfilename = f"{datetime.datetime.utcnow().strftime('%Y%m%d-%H%M%S')}_{self.sonde_type}_{int(self.sonde_freq)}.raw"
+            _outfilename = f"{datetime.datetime.now(datetime.timezone.utc).strftime('%Y%m%d-%H%M%S')}_{self.sonde_type}_{int(self.sonde_freq)}.raw"
             _outfilename = os.path.join(autorx.logging_path, _outfilename)
             self.raw_file_option = "-r"
         else:
@@ -1520,7 +1520,7 @@ class SondeDecoder(object):
                     )
 
                     # Overwrite the datetime field to make the email notifier happy
-                    _telemetry['datetime_dt'] = datetime.datetime.utcnow()
+                    _telemetry['datetime_dt'] = datetime.datetime.now(datetime.timezone.utc)
                     _telemetry["freq"] = "%.3f MHz" % (self.sonde_freq / 1e6)
 
                     # Send this to only the Email Notifier, if it exists.

--- a/auto_rx/autorx/email_notification.py
+++ b/auto_rx/autorx/email_notification.py
@@ -463,7 +463,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
         }
     )
 
@@ -485,7 +485,7 @@ if __name__ == "__main__":
             "heading": 0.0,
             "vel_h": 5.1,
             "vel_v": -5.0,
-            "datetime_dt": datetime.datetime.utcnow(),
+            "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
             "encrypted": True
         }
     )
@@ -506,7 +506,7 @@ if __name__ == "__main__":
         "heading": 0.0,
         "vel_h": 5.1,
         "vel_v": -5.0,
-        "datetime_dt": datetime.datetime.utcnow(),
+        "datetime_dt": datetime.datetime.now(datetime.timezone.utc),
     }
 
     print("Testing landing alert.")
@@ -516,7 +516,7 @@ if __name__ == "__main__":
         _test["alt"] = _test["alt"] - 10.0
         _test["lat"] = _test["lat"] + 0.001
         _test["lon"] = _test["lon"] + 0.001
-        _test["datetime_dt"] = datetime.datetime.utcnow()
+        _test["datetime_dt"] = datetime.datetime.now(datetime.timezone.utc)
         time.sleep(1)
 
     time.sleep(60)

--- a/auto_rx/autorx/emulation.py
+++ b/auto_rx/autorx/emulation.py
@@ -124,7 +124,7 @@ def emulate_telemetry(filename, port=55673, speed=1.0):
     _fields = _line.split(",")
     _telemetry_datetime = parse(_fields[0])
 
-    _current_datetime = datetime.datetime.utcnow()
+    _current_datetime = datetime.datetime.now(datetime.timezone.utc)
 
     for _line in _f:
         _fields = _line.split(",")

--- a/auto_rx/autorx/gps.py
+++ b/auto_rx/autorx/gps.py
@@ -17,7 +17,7 @@ def get_ephemeris(destination="ephemeris.dat"):
         logging.debug("GPS Grabber - Connecting to ESA's FTP Server...")
         ftp = ftplib.FTP("gssc.esa.int", timeout=10)
         ftp.login("anonymous", "anonymous")
-        ftp.cwd("gnss/data/daily/%s/" % datetime.datetime.utcnow().strftime("%Y"))
+        ftp.cwd("gnss/data/daily/%s/" % datetime.datetime.now(datetime.timezone.utc).strftime("%Y"))
         # Ideally we would grab this data from: YYYY/brdc/brdcDDD0.YYn.Z
         # .. but the ESA brdc folder seems to be getting of date. The daily directories are OK though!
         # So instead, we use: YYYY/DDD/brdcDDD0.YYn.Z

--- a/auto_rx/autorx/logger.py
+++ b/auto_rx/autorx/logger.py
@@ -223,7 +223,7 @@ class TelemetryLogger(object):
             else:
                 # Create a new log file.
                 _log_suffix = "%s_%s_%s_%d_sonde.log" % (
-                    datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S"),
+                    datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S"),
                     _id,
                     _type,
                     int(telemetry["freq_float"] * 1e3),  # Convert frequency to kHz
@@ -287,7 +287,7 @@ class TelemetryLogger(object):
             _type += "-XDATA"
 
         _subframe_log_suffix = "%s_%s_%s_%d_subframe.bin" % (
-            datetime.datetime.utcnow().strftime("%Y%m%d-%H%M%S"),
+            datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S"),
             _id,
             _type,
             int(telemetry["freq_float"] * 1e3),  # Convert frequency to kHz

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -969,7 +969,7 @@ class SondeScanner(object):
             (_freq_decimate, _power_decimate) = peak_decimation(freq / 1e6, power, 10)
             scan_result["freq"] = list(_freq_decimate)
             scan_result["power"] = list(_power_decimate)
-            scan_result["timestamp"] = datetime.datetime.utcnow().isoformat()
+            scan_result["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
             scan_result["peak_freq"] = []
             scan_result["peak_lvl"] = []
 

--- a/auto_rx/autorx/sonde_specific.py
+++ b/auto_rx/autorx/sonde_specific.py
@@ -16,7 +16,7 @@ def fix_datetime(datetime_str, local_dt_str=None):
 	"""
 
     if local_dt_str is None:
-        _now = datetime.datetime.utcnow()
+        _now = datetime.datetime.now(datetime.timezone.utc)
     else:
         _now = parse(local_dt_str)
 

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -120,7 +120,7 @@ class SondehubUploader(object):
             "uploader_callsign": self.user_callsign,
             "uploader_position": self.user_position,
             "uploader_antenna": self.user_antenna,
-            "time_received": datetime.datetime.utcnow().strftime(
+            "time_received": datetime.datetime.now(datetime.timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%S.%fZ"
             ),
         }

--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -96,14 +96,20 @@ function redraw_scan_chart(){
 		}
 
 	// Show the latest scan time.
-	if (getCookie('UTC') == 'false') {
-		temp_date = scan_chart_latest_timestamp;
-		temp_date = temp_date.slice(0, -3);
-		temp_date += "Z";
-		var date = new Date(temp_date);
-		var date_converted = date.toLocaleString(window.navigator.language,{hourCycle:'h23', year:"numeric", month:"2-digit", day:'2-digit', hour:'2-digit',minute:'2-digit', second:'2-digit'});
-		$('#scan_results').html('<b>Latest Scan:</b> ' + date_converted);
-	} else {
-		$('#scan_results').html('<b>Latest Scan:</b> ' + (scan_chart_latest_timestamp.slice(0, -3) + 'Z').replace("T", " ").replace("Z", "").slice(0, -4) + ' UTC');
+	var date = new Date(scan_chart_latest_timestamp);
+	var date_options = {
+		hourCycle: 'h23',
+		year: 'numeric',
+		month: '2-digit',
+		day: '2-digit',
+		hour: '2-digit',
+		minute: '2-digit',
+		second: '2-digit',
+		timeZoneName: 'short'
+	};
+	if (getCookie('UTC') != 'false') {
+		date_options.timeZone = 'UTC';
 	}
+	var date_converted = date.toLocaleString(window.navigator.language, date_options);
+	$('#scan_results').html('<b>Latest Scan:</b> ' + date_converted);
 }

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -366,7 +366,7 @@ def flask_export_log_files(serialb64=None):
 
         _zip = zip_log_files(_serial_list)
 
-        _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")
+        _ts = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), "%Y%m%d-%H%M%SZ")
 
         response = make_response(
             flask.send_file(
@@ -415,7 +415,7 @@ def flask_generate_kml(serialb64=None):
         log_files_to_kml(_log_files, _kml_file)
         _kml_file.seek(0)
 
-        _ts = datetime.datetime.strftime(datetime.datetime.utcnow(), "%Y%m%d-%H%M%SZ")
+        _ts = datetime.datetime.strftime(datetime.datetime.now(datetime.timezone.utc), "%Y%m%d-%H%M%SZ")
 
         response = make_response(
             flask.send_file(
@@ -667,7 +667,7 @@ class WebHandler(logging.Handler):
             # Convert log record into a dictionary
             log_data = {
                 "level": record.levelname,
-                "timestamp": datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 "msg": record.msg,
             }
             # Emit to all socket.io clients

--- a/auto_rx/utils/listener_nmea_crlf.py
+++ b/auto_rx/utils/listener_nmea_crlf.py
@@ -12,7 +12,7 @@
 import socket, json, sys, traceback
 from threading import Thread
 from dateutil.parser import parse
-from datetime import datetime, timedelta
+import datetime
 from io import StringIO
 import time
 
@@ -26,7 +26,7 @@ def fix_datetime(datetime_str, local_dt_str = None):
     '''
 
     if local_dt_str is None:
-        _now = datetime.utcnow()
+        _now = datetime.datetime.now(datetime.timezone.utc)
     else:
         _now = parse(local_dt_str)
 
@@ -54,18 +54,18 @@ def fix_datetime(datetime_str, local_dt_str = None):
         # We are within the window, and need to adjust the day backwards or forwards based on the sonde time.
         if _telem_dt.hour == 23 and _now.hour == 0:
             # Assume system clock running slightly fast, and subtract a day from the telemetry date.
-            _telem_dt = _telem_dt - timedelta(days=1)
+            _telem_dt = _telem_dt - datetime.timedelta(days=1)
 
         elif _telem_dt.hour == 00 and _now.hour == 23:
             # System clock running slow. Add a day.
-            _telem_dt = _telem_dt + timedelta(days=1)
+            _telem_dt = _telem_dt + datetime.timedelta(days=1)
 
         return _telem_dt
 
 def udp_listener_nmea_callback(info):
     ''' Handle a Payload Summary Message from UDPListener '''
 
-    dateRS = datetime.strptime(info['time'], '%H:%M:%S')
+    dateRS = datetime.datetime.strptime(info['time'], '%H:%M:%S')
 
     hms = dateRS.hour*10000.0+dateRS.minute*100.0+dateRS.second+dateRS.microsecond;
     dateNMEA = dateRS.year%100+dateRS.month*100+dateRS.day*10000

--- a/auto_rx/utils/plot_sonde_log.py
+++ b/auto_rx/utils/plot_sonde_log.py
@@ -417,7 +417,7 @@ def process_directory(log_dir, output_dir, status_file, time_limit = 60):
 
 
             # Calculate the age of the last data point in minutes.
-            _data_age = (pytz.utc.localize(datetime.datetime.utcnow()) - parse(last_time)).total_seconds() / 60.0
+            _data_age = (datetime.datetime.now(datetime.timezone.utc) - parse(last_time)).total_seconds() / 60.0
             if burst or (_data_age > time_limit):
                 # We consider this file to be finished.
                 _log_status[_basename]['complete'] = True


### PR DESCRIPTION
As of Python 3.12, [`datetime.utcnow()` is deprecated](https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow), with the recommended replacement being `datetime.now(timezone.utc)`. I made that replacement here. This was a simple search-and-replace, except in `listener_nmea_crlf.py` where I modified the code to be more like the other scripts. So far I haven't done much testing apart from firing up auto_rx.