### PR TITLE
Restore the previous time format in Scan Results

### DIFF
--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -96,20 +96,11 @@ function redraw_scan_chart(){
 		}
 
 	// Show the latest scan time.
-	var date = new Date(scan_chart_latest_timestamp);
-	var date_options = {
-		hourCycle: 'h23',
-		year: 'numeric',
-		month: '2-digit',
-		day: '2-digit',
-		hour: '2-digit',
-		minute: '2-digit',
-		second: '2-digit',
-		timeZoneName: 'short'
-	};
-	if (getCookie('UTC') != 'false') {
-		date_options.timeZone = 'UTC';
+	if (getCookie('UTC') == 'false') {
+		var date = new Date(scan_chart_latest_timestamp);
+		var date_converted = date.toLocaleString(window.navigator.language,{hourCycle:'h23', year:"numeric", month:"2-digit", day:'2-digit', hour:'2-digit',minute:'2-digit', second:'2-digit'});
+	} else {
+		var date_converted = scan_chart_latest_timestamp.slice(0, 19).replace("T", " ") + ' UTC'
 	}
-	var date_converted = date.toLocaleString(window.navigator.language, date_options);
 	$('#scan_results').html('<b>Latest Scan:</b> ' + date_converted);
 }


### PR DESCRIPTION
#867 changed the format of the time displayed in the Scan Results section. The old format was nicer, so I changed the code back to the old version, and simplified it to work with the updated format coming from the Python side.

My system now displays:

2024-03-29, 11:59:26

or:

2024-03-29 16:04:06 UTC