### PR TITLE
Don't update scan chart data until there's actual data

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -197,6 +197,10 @@
                 // There is Scan data ready for us!
                 // Grab the latest set of data.
                 $.getJSON("get_scan_data", function(data){
+                    if (data.freq.length == 0) {
+                        return;
+                    }
+
                     // Load the data into our data stores.
                     scan_chart_spectra.columns[0] = ['x_spectra'].concat(data.freq);
                     scan_chart_spectra.columns[1] = ['Spectra'].concat(data.power);


### PR DESCRIPTION
If the scan chart is open prior to the first scan being completed, an uncaught error occurs:
```
Uncaught Error: Source data is missing a component at (0,1)!
    convertColumnsToData http://localhost:5000/static/js/c3.min.js:2
    loadFromArgs http://localhost:5000/static/js/c3.min.js:2
    load http://localhost:5000/static/js/c3.min.js:2
    redraw_scan_chart http://localhost:5000/static/js/scan_chart.js:80
    <anonymous> http://localhost:5000/:213
    jQuery 8
    <anonymous> http://localhost:5000/:199
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    onreadystatechange http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    n http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    onreadystatechange http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    n http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    emit http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    value http://localhost:5000/static/js/socket.io.min.js:6
    onreadystatechange http://localhost:5000/static/js/socket.io.min.js:6
    jQuery 2
    <anonymous> http://localhost:5000/:106
    jQuery 13
c3.min.js:2:122014
```

This occurs because the `scan_chart_*` variables are overwritten, even though `get_scan_data` has not provided any data:

https://github.com/projecthorus/radiosonde_auto_rx/blob/d784d834c63b9ac1ac99751da3beb60d2ce5c7a0/auto_rx/autorx/templates/index.html#L199-L207

The `get_scan_data` response looks like so:
```
{
    "freq": [],
    "power": [],
    "peak_freq": [],
    "peak_lvl": [],
    "timestamp":
    "No data yet.",
    "threshold": 0
}
```

Line 205 accesses non-existent array indices in `data.freq`, thereby setting the x coordinates of the threshold line to `undefined`.

To avoid this, we can skip processing if `data.freq` is empty, which leaves the placeholder data displayed instead.