### PR TITLE
auto_rx/build.sh: exit immediatelly on error

### DIFF
--- a/auto_rx/build.sh
+++ b/auto_rx/build.sh
@@ -2,6 +2,8 @@
 #
 # Auto Sonde Decoder build script.
 
+set -e
+
 # Get the auto-rx version.
 AUTO_RX_VERSION="\"$(python3 -m autorx.version 2>/dev/null || python -m autorx.version)\""
 


### PR DESCRIPTION
This ensures script will not continue to build when error accures. Continuing the build after some part fails only brings more errors and makes the output harder to understand.