### PR TITLE
pre-commit: exclude auto_rx/autorx/static files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
   rev: v4.3.0
   hooks:
   - id: trailing-whitespace
+    exclude: |
+      (?x)(auto_rx/autorx/static)
   - id: end-of-file-fixer
+    exclude: |
+      (?x)(auto_rx/autorx/static)
   - id: check-added-large-files
   - id: check-executables-have-shebangs


### PR DESCRIPTION
Those are external downloaded packages, it does not make sense to use linting on them.

Mey-be we could get back to the idea of removing the extra whitespaces (automatically) and run some test within the GitHub?