### PR TITLE
Fix KA9Q support to work with latest commit (2024-06-11, 26a8015)

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.7.3-beta16"
+__version__ = "1.7.3-beta17"
 
 
 # Global Variables

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -119,9 +119,10 @@ def ka9q_get_iq_cmd(
     # Get the 'PCM' version of the server name, where as assume -pcm is added to the first part of the hostname.
     _pcm_host = sdr_hostname.split('.')[0] + "-pcm." + ".".join(sdr_hostname.split(".")[1:])
 
-    # pcmcat -2 -s 404090000 sonde-pcm.local
+    # Example: pcmcat -s 404090000 sonde-pcm.local
+    # -2 option was removed sometime in early 2024.
     _cmd = (
-        f"pcmcat -2 "
+        f"pcmcat "
         f"-s {int(frequency)} "
         f"{_pcm_host} |"
     )

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -75,7 +75,7 @@ def test_sdr(
             f"tune "
             f"--samprate 48000 --mode iq "
             f"--frequency {int(check_freq)} "
-            f"--ssrc {int(check_freq)} "
+            f"--ssrc {int(check_freq)}314 "
             f"--radio {sdr_hostname}"
         )
 
@@ -112,7 +112,7 @@ def test_sdr(
             f"tune "
             f"--samprate 48000 --mode iq "
             f"--frequency 0 "
-            f"--ssrc {int(check_freq)} "
+            f"--ssrc {int(check_freq)}314 "
             f"--radio {sdr_hostname}"
         )
 


### PR DESCRIPTION
Updates in ka9q-radio broke compatibility, as a command line option to pcmcat was removed. 
