### PR TITLE
pre-commit: do not lint files insta static folder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,10 @@ repos:
   rev: v4.3.0
   hooks:
   - id: trailing-whitespace
+    exclude: |
+      (?x)(auto_rx/autorx/static)
   - id: end-of-file-fixer
+    exclude: |
+      (?x)(auto_rx/autorx/static)
   - id: check-added-large-files
   - id: check-executables-have-shebangs


### PR DESCRIPTION
Those files are from external source and should not be reformated.