### PR TITLE
1.7.5-beta4 - Increase precision of estimated frequency output, add rotator azimuth_only

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -1009,6 +1009,7 @@ def main():
                 config["rotator_home_azimuth"],
                 config["rotator_home_elevation"],
             ],
+            azimuth_only=config["rotator_azimuth_only"]
         )
 
         exporter_objects.append(_rotator)

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.7.5-beta3"
+__version__ = "1.7.5-beta4"
 
 # Global Variables
 

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -148,6 +148,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         "rotator_homing_delay": 10,
         "rotator_home_azimuth": 0,
         "rotator_home_elevation": 0,
+        "rotator_azimuth_only": False,
         # OziExplorer Settings
         "ozi_enabled": False,
         "ozi_update_rate": 5,
@@ -758,6 +759,15 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 "Config - Missing save_cal_data option (new in v1.7.1), using default (False)"
             )
             auto_rx_config["save_cal_data"] = False
+
+        # 1.7.5 - Azimuth-Only Rotator configuration
+        try:
+            auto_rx_config['rotator_azimuth_only'] = config.getboolean(
+                "rotator", "azimuth_only"
+            )
+        except:
+            logging.debug("Config - Missing rotator azimuth_only option (new in v1.7.5), using default (False)")
+            auto_rx_config['rotator_azimuth_only'] = False
 
         # If we are being called as part of a unit test, just return the config now.
         if no_sdr_test:

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -1592,7 +1592,7 @@ class SondeDecoder(object):
 
                     # Overwrite the datetime field to make the email notifier happy
                     _telemetry['datetime_dt'] = datetime.datetime.now(datetime.timezone.utc)
-                    _telemetry["freq"] = "%.3f MHz" % (self.sonde_freq / 1e6)
+                    _telemetry["freq"] = "%.4f MHz" % (self.sonde_freq / 1e6)
 
                     # Send this to only the Email Notifier, if it exists.
                     for _exporter in self.exporters:
@@ -1667,7 +1667,7 @@ class SondeDecoder(object):
                 #_telemetry["subtype"] = self.sonde_type
 
             _telemetry["freq_float"] = self.sonde_freq / 1e6
-            _telemetry["freq"] = "%.3f MHz" % (self.sonde_freq / 1e6)
+            _telemetry["freq"] = "%.4f MHz" % (self.sonde_freq / 1e6)
 
             # Add in information about the SDR used.
             _telemetry["sdr_device_idx"] = self.rtl_device_idx

--- a/auto_rx/autorx/rotator.py
+++ b/auto_rx/autorx/rotator.py
@@ -134,6 +134,7 @@ class Rotator(object):
         rotator_homing_enabled=False,
         rotator_homing_delay=10,
         rotator_home_position=[0.0, 0.0],
+        azimuth_only=False
     ):
         """ Start a new Rotator Control object. 
 
@@ -151,6 +152,7 @@ class Rotator(object):
                 and whenever no telemetry has been observed for <rotator_homing_delay> minutes.
             rotator_homing_delay (int): Move the rotator to a home position if no telemetry is received within X minutes.
             rotator_home_position (tuple): Rotator home position, as an [azimuth, elevation] list, in degrees (true).
+            azimuth_only (bool): If set, force all elevation data to 0.
 
         """
 
@@ -163,6 +165,7 @@ class Rotator(object):
         self.rotator_homing_enabled = rotator_homing_enabled
         self.rotator_homing_delay = rotator_homing_delay
         self.rotator_home_position = rotator_home_position
+        self.azimuth_only = azimuth_only
 
         # Latest telemetry.
         self.latest_telemetry = None
@@ -219,6 +222,11 @@ class Rotator(object):
         if (_azimuth_diff > 180.0):
             _azimuth_diff = abs(_azimuth_diff - 360.0)
 
+        # For azimuth-only rotators, we force elevation to 0, and ignore any incoming elevation data
+        # (which should be 0 anyway)
+        if self.azimuth_only:
+            _curr_el = 0.0
+            elevation = 0.0
 
         if (_azimuth_diff > self.rotator_update_threshold) or (
             abs(elevation - _curr_el) > self.rotator_update_threshold

--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -336,8 +336,8 @@ class SondehubUploader(object):
             _output["snr"] = telemetry["snr"]
 
         if "f_centre" in telemetry:
-            _freq = round(telemetry["f_centre"] / 1e3) # Hz -> kHz
-            _output["frequency"] = _freq / 1e3 # kHz -> MHz
+            # Don't round the frequency to 1 kHz anymore! Let's make use of the full precision data...
+            _output["frequency"] = telemetry["f_centre"] / 1e6
         
         if "tx_frequency" in telemetry:
             _output["tx_frequency"] = telemetry["tx_frequency"] / 1e3 # kHz -> MHz

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -438,6 +438,9 @@ rotator_homing_delay = 10
 # Rotator home azimuth/elevation, in degrees true.
 rotator_home_azimuth = 0.0
 rotator_home_elevation = 0.0
+# Azimuth-only rotator - set this to True if your rotator only moves in Azimuth
+# This will force all elevation settings to 0
+azimuth_only = False
 
 
 ###########

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -438,6 +438,9 @@ rotator_homing_delay = 10
 # Rotator home azimuth/elevation, in degrees true.
 rotator_home_azimuth = 0.0
 rotator_home_elevation = 0.0
+# Azimuth-only rotator - set this to True if your rotator only moves in Azimuth
+# This will force all elevation settings to 0
+azimuth_only = False
 
 
 ###########


### PR DESCRIPTION
Send full-precision frequency estimator data to sondehub (We'll see how this goes... May still reduce precision a little). 
Also add azimuth_only option to the rotator settings, which will force elevation to 0.