### PR TITLE
Cache wheels for container builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -3,6 +3,7 @@ name: Container image
 on:
   push:
     branches:
+      - 'master'
       - 'testing'
     tags:
       - 'v*'

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -17,10 +17,24 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/386, linux/arm64, linux/arm/v6, linux/arm/v7]
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Declare platform
         run: |
           platform=${{ matrix.platform }}
           echo "PLATFORM=${platform//\//-}" >> $GITHUB_ENV
+
+      - name: Cache wheels
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/wheels
+          key: wheels-${{ env.PLATFORM }}-${{ github.run_id }}
+          restore-keys: |
+            wheels-${{ env.PLATFORM }}-
+
+      - name: List wheels
+        run: ls -lR ${{ github.workspace }}/wheels || true
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
@@ -29,7 +43,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -41,19 +55,34 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
 
-      - name: Build images and push by digest
+      - name: Build stage
         id: build
         uses: docker/build-push-action@v6
         with:
+          context: .
           platforms: ${{ matrix.platform }}
+          provenance: false
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=local,dest=/tmp/build-output
+          cache-to: type=local,dest=/tmp/build-cache,mode=max
+          target: build
+
+      - name: Final stage and push by digest
+        id: final
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          provenance: false
           labels: ${{ steps.meta.outputs.labels }}
           outputs: type=image,name=ghcr.io/${{ github.repository }},push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' && 'true' || 'false' }}
+          cache-from: type=local,src=/tmp/build-cache
 
       - name: Export digest
         if: ${{ github.event_name != 'pull_request' }}
         run: |
           mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
+          digest="${{ steps.final.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
@@ -64,6 +93,11 @@ jobs:
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
+
+      - name: Move and list wheels
+        run: |
+          mv -f /tmp/build-output/root/.cache/pip/wheels ${{ github.workspace }}/ || true
+          ls -lR ${{ github.workspace }}/wheels || true
 
   merge:
     name: Publish multi-platform image
@@ -88,7 +122,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,12 @@ RUN apt-get update && \
     python3-wheel && \
   rm -rf /var/lib/apt/lists/*
 
+# Copy in existing wheels.
+COPY wheel[s]/ /root/.cache/pip/wheels/
+
+# No wheels might exist.
+RUN mkdir -p /root/.cache/pip/wheels/
+
 # Copy in requirements.txt.
 COPY auto_rx/requirements.txt \
   /root/radiosonde_auto_rx/auto_rx/requirements.txt


### PR DESCRIPTION
This will be especially helpful when iterating on a branch, when the versions of dependencies are unlikely to have changed significantly.