### PR TITLE
Automatic weekly build

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -9,6 +9,8 @@ on:
       - 'v*'
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '25 4 * * 3'
 
 jobs:
   build:


### PR DESCRIPTION
This will both keep the wheel cache warm, as well as ensure that we don't have any breakages waiting for us do to upstream changes in dependencies.

For consistency, runs 4:25am on a Wednesday UTC. Time and day picked at random.

We won't see the full benefits of this caching until this makes it from `testing` to `master`.