### PR TITLE
Change iMet54 subtype names

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.7.5-beta5"
+__version__ = "1.7.5-beta6"
 
 # Global Variables
 

--- a/demod/mod/imet54mod.c
+++ b/demod/mod/imet54mod.c
@@ -581,7 +581,7 @@ static int print_position(gpx_t *gpx, int len, int ecc_frm, int ecc_tlm, int ecc
     // prnGPS,prnTPU
     if (gpx->option.jsn && frm_ok && (crc_ok || std_ok) && (gpx->status&0x30)==0x30) {
         char *ver_jsn = NULL;
-        char *subtype = (rs_type == 54) ? "IMET54" : "IMET50";
+        char *subtype = (rs_type == 54) ? "iMet-54" : "iMet-50";
         unsigned long count_day = (unsigned long)(gpx->std*3600 + gpx->min*60 + gpx->sek+0.5);  // (gpx->timems/1e3+0.5) has gaps
         fprintf(stdout, "{ \"type\": \"%s\"", "IMET5");
         fprintf(stdout, ", \"frame\": %lu", count_day);


### PR DESCRIPTION
Possibly fixing a sondehub ingestion bug.