### PR TITLE
Allow changing oziplotter and summary target host

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -971,18 +971,30 @@ def main():
 
     # OziExplorer
     if config["ozi_enabled"] or config["payload_summary_enabled"]:
-        if config["ozi_enabled"]:
+        if config["ozi_host"]:
+            _ozi_host = config["ozi_host"]
+        else:
+            _ozi_host = None
+
+        if config["ozi_port"]:
             _ozi_port = config["ozi_port"]
         else:
             _ozi_port = None
 
-        if config["payload_summary_enabled"]:
+        if config["payload_summary_host"]:
+            _summary_host = config["payload_summary_host"]
+        else:
+            _summary_host = None
+
+        if config["payload_summary_port"]:
             _summary_port = config["payload_summary_port"]
         else:
             _summary_port = None
 
         _ozimux = OziUploader(
+            ozimux_host=_ozi_host,
             ozimux_port=_ozi_port,
+            payload_summary_host=_summary_host,
             payload_summary_port=_summary_port,
             update_rate=config["ozi_update_rate"],
             station=config["habitat_uploader_callsign"],

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -976,7 +976,7 @@ def main():
         else:
             _ozi_host = None
 
-        if config["ozi_port"]:
+        if config["ozi_enabled"]: # Causes port to be set to None which disables the export.
             _ozi_port = config["ozi_port"]
         else:
             _ozi_port = None
@@ -986,7 +986,7 @@ def main():
         else:
             _summary_host = None
 
-        if config["payload_summary_port"]:
+        if config["payload_summary_enabled"]: # Causes port to be set to None which disables the export.
             _summary_port = config["payload_summary_port"]
         else:
             _summary_port = None

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -152,8 +152,10 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         # OziExplorer Settings
         "ozi_enabled": False,
         "ozi_update_rate": 5,
+        "ozi_host": "<broadcast>",
         "ozi_port": 55681,
         "payload_summary_enabled": False,
+        "payload_summary_host": "<broadcast>",
         "payload_summary_port": 55672,
         # Debugging settings
         "save_detection_audio": False,

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -771,6 +771,17 @@ def read_auto_rx_config(filename, no_sdr_test=False):
             logging.debug("Config - Missing rotator azimuth_only option (new in v1.7.5), using default (False)")
             auto_rx_config['rotator_azimuth_only'] = False
 
+        # 1.7.5 - Targeted summary output
+        try:
+            auto_rx_config["ozi_host"] = config.get("oziplotter", "ozi_host")
+            auto_rx_config["payload_summary_host"] = config.get("oziplotter", "payload_summary_host")
+        except:
+            logging.warning(
+                "Config - Missing ozi_host or payload_summary_host option (new in v1.7.5), using default (<broadcast>)"
+            )
+            auto_rx_config["ozi_host"] = "<broadcast>"
+            auto_rx_config["payload_summary_host"] = "<broadcast>"
+            
         # If we are being called as part of a unit test, just return the config now.
         if no_sdr_test:
             return auto_rx_config

--- a/auto_rx/autorx/ozimux.py
+++ b/auto_rx/autorx/ozimux.py
@@ -48,7 +48,9 @@ class OziUploader(object):
 
     def __init__(
         self,
+        ozimux_host="<broadcast>",
         ozimux_port=None,
+        payload_summary_host="<broadcast>",
         payload_summary_port=None,
         update_rate=5,
         station="auto_rx",
@@ -56,12 +58,16 @@ class OziUploader(object):
         """ Initialise an OziUploader Object.
 
         Args:
+            ozimux_host (str): UDP host to push ozimux/oziplotter messages to.
             ozimux_port (int): UDP port to push ozimux/oziplotter messages to. Set to None to disable.
+            payload_summary_host (str): UDP host to push payload summary messages to.
             payload_summary_port (int): UDP port to push payload summary messages to. Set to None to disable.
             update_rate (int): Time in seconds between updates.
         """
 
+        self.ozimux_host = ozimux_host
         self.ozimux_port = ozimux_port
+        self.payload_summary_host = payload_summary_host
         self.payload_summary_port = payload_summary_port
         self.update_rate = update_rate
         self.station = station
@@ -106,7 +112,7 @@ class OziUploader(object):
 
             try:
                 _ozisock.sendto(
-                    _sentence.encode("ascii"), ("<broadcast>", self.ozimux_port)
+                    _sentence.encode("ascii"), (self.ozimux_host, self.ozimux_port)
                 )
             # Catch any socket errors, that may occur when attempting to send to a broadcast address
             # when there is no network connected. In this case, re-try and send to localhost instead.
@@ -184,7 +190,7 @@ class OziUploader(object):
             try:
                 _s.sendto(
                     json.dumps(packet).encode("ascii"),
-                    ("<broadcast>", self.payload_summary_port),
+                    (self.payload_summary_host, self.payload_summary_port),
                 )
             # Catch any socket errors, that may occur when attempting to send to a broadcast address
             # when there is no network connected. In this case, re-try and send to localhost instead.

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -341,7 +341,11 @@ ozi_update_rate = 5
 # Note - this cannot be enabled in a multi-SDR configuration.
 ozi_enabled = False
 
-# OziMux UDP Broadcast output port.
+# OziMux UDP target host.
+# Defaults to broadcasting
+ozi_host = <broadcast>
+
+# OziMux UDP output port.
 # Set to 8942 to send packets directly into OziPlotter, or set to 55681 to send via OziMux
 ozi_port = 8942
 
@@ -349,6 +353,7 @@ ozi_port = 8942
 # Using this output allows multiple sondes to be plotted in Chasemapper.
 # As of 2019-05, this is enabled by default.
 payload_summary_enabled = True
+payload_summary_host = <broadcast>
 payload_summary_port = 55673
 
 

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -342,7 +342,11 @@ ozi_update_rate = 5
 # Note - this cannot be enabled in a multi-SDR configuration.
 ozi_enabled = False
 
-# OziMux UDP Broadcast output port.
+# OziMux UDP target host.
+# Defaults to broadcasting
+ozi_host = <broadcast>
+
+# OziMux UDP output port.
 # Set to 8942 to send packets directly into OziPlotter, or set to 55681 to send via OziMux
 ozi_port = 8942
 
@@ -350,6 +354,7 @@ ozi_port = 8942
 # Using this output allows multiple sondes to be plotted in Chasemapper.
 # As of 2019-05, this is enabled by default.
 payload_summary_enabled = True
+payload_summary_host = <broadcast>
 payload_summary_port = 55673
 
 


### PR DESCRIPTION
Still needs testing, I rarely get any sondes out there. Changed the emulation.py script locally to allow an OziUploader object and that worked, unsure about the configuration loading.