### PR TITLE
Put X axis ticks at exact MHz values

### DIFF
--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -53,10 +53,13 @@ function setup_scan_chart(){
 	    axis:{
 	        x:{
 	            tick:{
-                    culling: {
-                        max: window.innerWidth > 1100 ? 10 : 4
-                    },
-	                format: function (x) { return x.toFixed(3); }
+                    values: [
+                        400, 400.5, 401, 401.5, 402, 402.5, 403,
+                        403.5, 404, 404.5, 405, 405.5, 406,
+                        1676, 1678, 1680, 1682, 1684, 1686, 1688,
+                        1690, 1692, 1694, 1696, 1698, 1700
+                    ],
+                    outer: false
 	            },
 	            label:"Frequency (MHz)"
 	        },


### PR DESCRIPTION
The X axis of the scan plot is unwieldy, with hundreds of tick marks and odd frequencies displayed:

![Screenshot from 2024-10-02 17-31-24](https://github.com/user-attachments/assets/f3c68460-f0f8-4691-bd99-72b3c2e6be49)

Providing a fixed list of frequencies cleans things up nicely:

![Screenshot from 2024-10-02 17-29-25](https://github.com/user-attachments/assets/5c416f63-0a91-43c7-826f-40fe31925807)

I included frequencies for both the 403 MHz and 1680 MHz bands. For the 1680 MHz band, I chose a 2 MHz spacing to avoid having too many labels when the full 1675-1700 MHz band is scanned.