### PR TITLE
Remove transition from left margin of map

### DIFF
--- a/auto_rx/autorx/static/css/main.css
+++ b/auto_rx/autorx/static/css/main.css
@@ -204,7 +204,6 @@ button[disabled]{
 }
 
 #main {
-  transition: margin-left .5s;
   padding: 16px;
   padding-top: 5px;
   flex: auto;


### PR DESCRIPTION
When the Historical page is opened, the map is not centered:

![Screenshot from 2024-10-11 22-21-15](https://github.com/user-attachments/assets/7277085f-b4b7-4db2-a66a-c4abb1746b2e)

Closing the Sonde List sidebar also leaves the map uncentered, as does opening or closing the Log sidebar on the main page.

This happens because `mymap.invalidateSize()` is called immediately, but the left margin of the map moves for the next half second due to a CSS transition. The right margin does not have such a transition, and therefore doesn't suffer the same problem.

Removing the CSS transition solves the problem, and the map is then correctly centered in all cases.