### PR TITLE
Speed up log file processing

### DIFF
--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -53,8 +53,16 @@ def log_filename_to_stats(filename, quicklook=False):
         _fields = _basename.split("_")
 
         # First field is the date/time the sonde was first received.
-        _date_str = _fields[0] + "Z"
-        _date_dt = parse(_date_str)
+        _date_str = _fields[0]
+        _date_dt = datetime.datetime(
+            int(_date_str[0:4]),
+            int(_date_str[4:6]),
+            int(_date_str[6:8]),
+            int(_date_str[9:11]),
+            int(_date_str[11:13]),
+            int(_date_str[13:15]),
+            tzinfo=datetime.timezone.utc
+        )
 
         # Calculate age
         _age_td = _now_dt - _date_dt


### PR DESCRIPTION
After thousands of log files have accumulated, opening the Historical page becomes slow. A lot of the wait time comes from the `list_log_files` function, which scans the log files and summarizes them. I profiled this function and found that nearly half of the execution time is spent in `dateutil.parser.parse`, which is used to parse the time from the beginning of the log filename. I presume the `parse` function is slow because it must guess what time format has been used.

I tried switching to `datetime.datetime.strptime`, and this gave a significant speedup, but still a decent amount of time was spent in `strptime`, perhaps because it needs to parse the format string argument. Manually converting the pieces to integers and passing them directly into `datetime.datetime()` reduced the processing time to a negligible amount, and reduced the execution time of `list_log_files` by about 45%.