### PR TITLE
Remove unused data from /get_log_list

### DIFF
--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -22,14 +22,13 @@ from dateutil.parser import parse
 from autorx.utils import (
     short_type_lookup,
     short_short_type_lookup,
-    readable_timedelta,
     strip_sonde_serial,
     position_info,
 )
 from autorx.geometry import GenericTrack, getDensity
 
 
-def log_filename_to_stats(filename, quicklook=False):
+def log_filename_to_stats(filename, quicklook=False, stats_fields=False):
     """ Attempt to extract information about a log file from a supplied filename """
     # Example log file name: 20210430-235413_IMET-89F2720A_IMET_401999_sonde.log
     # ./log/20200320-063233_R2230624_RS41_402500_sonde.log
@@ -64,10 +63,6 @@ def log_filename_to_stats(filename, quicklook=False):
             tzinfo=datetime.timezone.utc
         )
 
-        # Calculate age
-        _age_td = _now_dt - _date_dt
-        _time_delta = readable_timedelta(_age_td)
-
         # Re-format date
         _date_str2 = _date_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
 
@@ -84,7 +79,6 @@ def log_filename_to_stats(filename, quicklook=False):
 
         _output = {
             "datetime": _date_str2,
-            "age": _time_delta,
             "serial": _serial,
             "type": _type_str,
             "short_type": _short_type,
@@ -94,15 +88,16 @@ def log_filename_to_stats(filename, quicklook=False):
 
         if quicklook:
             try:
-                _quick = log_quick_look(filename)
+                _quick = log_quick_look(filename, stats_fields=stats_fields)
                 if _quick:
                     _output["first"] = _quick["first"]
                     _output["last"] = _quick["last"]
-                    _output["has_snr"] = _quick["has_snr"]
                     _output["max_range"] = int(max(_output["first"]["range_km"],_output["last"]["range_km"]))
                     _output["last_range"] = int(_output["last"]["range_km"])
                     _output["min_height"] = int(_output["last"]["alt"])
-                    _output["freq"] = _quick["first"]["freq"]
+                    if stats_fields:
+                        _output["has_snr"] = _quick["has_snr"]
+
             except Exception as e:
                 logging.error(f"Could not quicklook file {filename}: {str(e)}")
 
@@ -113,7 +108,7 @@ def log_filename_to_stats(filename, quicklook=False):
         return None
 
 
-def log_quick_look(filename):
+def log_quick_look(filename, stats_fields=False):
     """ Attempt to read in the first and last line in a log file, and return the first/last position observed. """
 
     _filesize = os.path.getsize(filename)
@@ -142,7 +137,6 @@ def log_quick_look(filename):
         _first_lat = float(_fields[3])
         _first_lon = float(_fields[4])
         _first_alt = float(_fields[5])
-        _first_freq = float(_fields[13])
         _pos_info = position_info(
             (
                 autorx.config.global_config["station_lat"],
@@ -156,11 +150,11 @@ def log_quick_look(filename):
             "lat": _first_lat,
             "lon": _first_lon,
             "alt": _first_alt,
-            "range_km": _pos_info["straight_distance"] / 1000.0,
-            "bearing": _pos_info["bearing"],
-            "elevation": _pos_info["elevation"],
-            "freq": _first_freq,
+            "range_km": round(_pos_info["straight_distance"] / 1000.0, 1),
+            "bearing": round(_pos_info["bearing"], 1),
         }
+        if stats_fields:
+            _output["first"]["elevation"] = _pos_info["elevation"]
     except Exception as e:
         # Couldn't read the first line, so likely no data.
         return None
@@ -196,10 +190,11 @@ def log_quick_look(filename):
             "lat": _last_lat,
             "lon": _last_lon,
             "alt": _last_alt,
-            "range_km": _pos_info["straight_distance"] / 1000.0,
-            "bearing": _pos_info["bearing"],
-            "elevation": _pos_info["elevation"],
+            "range_km": round(_pos_info["straight_distance"] / 1000.0, 1),
+            "bearing": round(_pos_info["bearing"], 1),
         }
+        if stats_fields:
+            _output["last"]["elevation"] = _pos_info["elevation"]
         return _output
     except Exception as e:
         # Couldn't read in the last line for some reason.
@@ -209,7 +204,7 @@ def log_quick_look(filename):
         return _output
 
 
-def list_log_files(quicklook=False, custom_log_dir=None):
+def list_log_files(quicklook=False, stats_fields=False, custom_log_dir=None):
     """ Look for all sonde log files within the logging directory """
 
     # Output list, which will contain one object per log file, ordered by time
@@ -228,7 +223,7 @@ def list_log_files(quicklook=False, custom_log_dir=None):
     _log_files.reverse()
 
     for _file in _log_files:
-        _entry = log_filename_to_stats(_file, quicklook=quicklook)
+        _entry = log_filename_to_stats(_file, quicklook=quicklook, stats_fields=stats_fields)
         if _entry:
             _output.append(_entry)
 

--- a/auto_rx/autorx/stats.py
+++ b/auto_rx/autorx/stats.py
@@ -29,7 +29,6 @@ import matplotlib.pyplot as plt
 from dateutil.parser import parse
 from autorx.utils import (
     short_type_lookup,
-    readable_timedelta,
     strip_sonde_serial,
     position_info,
 )
@@ -228,7 +227,7 @@ if __name__ == "__main__":
 
     # Read in the log files.
     logging.info("Quick-Looking Log Files")
-    log_list = list_log_files(quicklook=True, custom_log_dir=args.log)
+    log_list = list_log_files(quicklook=True, stats_fields=True, custom_log_dir=args.log)
     logging.info(f"Loaded in {len(log_list)} log files.")
 
 

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -368,24 +368,6 @@ def generate_aprs_id(sonde_data):
         return _object_name
 
 
-def readable_timedelta(duration: timedelta):
-    """
-    Convert a timedelta into a readable string.
-    From: https://codereview.stackexchange.com/a/245215
-    """
-    data = {}
-    data["months"], remaining = divmod(duration.total_seconds(), 2_592_000)
-    data["days"], remaining = divmod(remaining, 86_400)
-    data["hours"], remaining = divmod(remaining, 3_600)
-    data["minutes"], _foo = divmod(remaining, 60)
-
-    time_parts = [f"{round(value)} {name}" for name, value in data.items() if value > 0]
-    if time_parts:
-        return " ".join(time_parts)
-    else:
-        return "below 1 second"
-
-
 class AsynchronousFileReader(threading.Thread):
     """ Asynchronous File Reader
     Helper class to implement asynchronous reading of a file

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -320,7 +320,7 @@ def shutdown_flask(shutdown_key):
 @app.route("/get_log_list")
 def flask_get_log_list():
     """ Return a list of log files, as a list of objects """
-    return json.dumps(list_log_files(quicklook=True))
+    return json.dumps(list_log_files(quicklook=True), separators=(',', ':'))
 
 def flask_running():
     global flask_shutdown_key


### PR DESCRIPTION
When viewing the Historical page over an internet connection, the time to load `/get_log_list` can be significant. By removing unused and redundant information, its size can be reduced by about 36%.

Here are the relevant changes:

* Remove JSON whitespace using `separators=(',', ':')`.
* Remove the `age` field, which is unused.
* Remove the `first.freq` and `last.freq` fields, which are unused and duplicate the `freq` field.
* Remove the `first.evelation` and `last.elevation` fields, which are only used by `stats.py`.
* Remove the `has_snr` field, which is only used by `stats.py`.
* Round `first.range_km`, `first.bearing`, `last.range_km`, and `last.bearing` to one decimal place.

Before:

`{"datetime": "2024-10-11T11:26:09Z", "age": "16 hours 56 minutes", "serial": "W2234350", "type": "Vaisala RS41", "short_type": "RS41", "freq": 404.001, "lines": 5481, "first": {"datetime": "2024-10-11T11:26:24.999Z", "lat": 42.63111, "lon": -83.37151, "alt": 5709.7, "range_km": 90.73564528807711, "bearing": 316.4399360433176, "elevation": 3.0735023874311675, "freq": 404.001}, "last": {"datetime": "2024-10-11T13:32:41.997Z", "lat": 42.29325, "lon": -81.80325, "alt": 2742.9, "range_km": 72.03010793292015, "bearing": 67.04731122106921, "elevation": 1.6987054953634557}, "has_snr": true, "max_range": 90, "last_range": 72, "min_height": 2742}`

After:

`{"datetime":"2024-10-11T11:26:09Z","serial":"W2234350","type":"Vaisala RS41","short_type":"RS41","freq":404.001,"lines":5481,"first":{"datetime":"2024-10-11T11:26:24.999Z","lat":42.63111,"lon":-83.37151,"alt":5709.7,"range_km":90.7,"bearing":316.4},"last":{"datetime":"2024-10-11T13:32:41.997Z","lat":42.29325,"lon":-81.80325,"alt":2742.9,"range_km":72.0,"bearing":67.0},"max_range":90,"last_range":72,"min_height":2742}`