### PR TITLE
Rotator Control Improvements

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -708,21 +708,6 @@ def email_error(message="foo"):
     else:
         logging.debug("Not sending Email notification, as Email not configured.")
 
-def move_rotator(az=0, el=0, home=False):
-    """Move rotator to specified position or trigger homing routine"""
-    global exporter_objects
-    
-    if home:
-        for _exporter in exporter_objects:
-            if "home_rotator" in dir(_exporter):
-                _exporter.home_rotator()
-                break
-    else:
-        for _exporter in exporter_objects:
-            if "move_rotator" in dir(_exporter):
-                _exporter.move_rotator(az, el)
-                break
-
 def main():
     """Main Loop"""
     global config, exporter_objects, exporter_functions, logging_level, rs92_ephemeris, gpsd_adaptor, email_exporter
@@ -1040,6 +1025,8 @@ def main():
 
         exporter_objects.append(_rotator)
         exporter_functions.append(_rotator.add)
+
+        autorx.rotator_object = _rotator
 
     # Sondehub v2 Database
     if config["sondehub_enabled"]:

--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -708,6 +708,20 @@ def email_error(message="foo"):
     else:
         logging.debug("Not sending Email notification, as Email not configured.")
 
+def move_rotator(az=0, el=0, home=False):
+    """Move rotator to specified position or trigger homing routine"""
+    global exporter_objects
+    
+    if home:
+        for _exporter in exporter_objects:
+            if "home_rotator" in dir(_exporter):
+                _exporter.home_rotator()
+                break
+    else:
+        for _exporter in exporter_objects:
+            if "move_rotator" in dir(_exporter):
+                _exporter.move_rotator(az, el)
+                break
 
 def main():
     """Main Loop"""

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -44,5 +44,8 @@ scan_results = Queue()
 # Global scan inhibit flag, used by web interface.
 scan_inhibit = False
 
+# Rotator object
+rotator_object = None
+
 # Logging Directory
 logging_path = "./log/"

--- a/auto_rx/autorx/rotator.py
+++ b/auto_rx/autorx/rotator.py
@@ -298,7 +298,7 @@ class Rotator(object):
                     _telem_age = time.time() - _telem_time
 
                     # If the telemetry is older than our homing delay, move to our home position.
-                    if _telem_age > self.rotator_homing_delay * 60.0:
+                    if _telem_age > self.rotator_homing_delay * 60.0 and not self.rotator_homed:
                         self.home_rotator()
 
                     else:

--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -289,7 +289,7 @@ function start_decoder(){
     // Grab the selected type
     _type = $('#sonde-type-select').val();
 
-    // Parse to a floar.
+    // Parse to a float.
     _freq_float = parseFloat(_freq);
     if(_freq_float > autorx_config["max_freq"]){
         alert("Supplied frequency above maximum (" + autorx_config["max_freq"] + " MHz)");
@@ -308,6 +308,87 @@ function start_decoder(){
         {password: _api_password, freq: _freq_hz, type: _type},
         function(data){
             alert("Added requested decoder to results queue.")
+            pause_web_controls();
+            setTimeout(resume_web_controls,10000);
+        }
+    ).fail(function(xhr, status, error){
+        console.log(error);
+        // Otherwise, we probably got a 403 error (forbidden) which indicates the password was bad.
+        if(error == "FORBIDDEN"){
+            $("#password-header").html("<h2>Incorrect Password</h2>");
+        }
+    });
+}
+
+function move_rotator(){
+    // Move rotator to requested position
+
+    // Re-verify the password. This will occur async, so wont stop the main request from going ahead,
+    // but will at least present an error for the user.
+    verify_password();
+
+    // Grab the password
+    _api_password = getCookie("password");
+
+    // Grab the az/el input
+    _az = $('#azimuth-input').val();
+    _el = $('#azimuth-input').val();
+
+    // Parse to a float.
+    _az_float = parseFloat(_az);
+    if(_az_float > 360){
+        alert("Supplied azimuth above 360 degrees");
+        return;
+    }
+    if(_az_float < 0){
+        alert("Supplied azimuth below 0 degrees");
+        return;
+    }
+
+    _el_float = parseFloat(_el);
+    if(_el_float > 90){
+        alert("Supplied elevation above 360 degrees");
+        return;
+    }
+    if(_el_float < 0){
+        alert("Supplied elevation below 0 degrees");
+        return;
+    }
+
+    // Do the request
+    $.post(
+        "move_rotator", 
+        {password: _api_password, az: _az_float.toFixed(1), el: _el_float.toFixed(1)},
+        function(data){
+            alert("Moving rotator to " + _az + ", " + _el + ".");
+            pause_web_controls();
+            setTimeout(resume_web_controls,10000);
+        }
+    ).fail(function(xhr, status, error){
+        console.log(error);
+        // Otherwise, we probably got a 403 error (forbidden) which indicates the password was bad.
+        if(error == "FORBIDDEN"){
+            $("#password-header").html("<h2>Incorrect Password</h2>");
+        }
+    });
+}
+
+function home_rotator(){
+    // Home rotator
+
+    // Re-verify the password. This will occur async, so wont stop the main request from going ahead,
+    // but will at least present an error for the user.
+    verify_password();
+
+    // Grab the password
+    _api_password = getCookie("password");
+
+    // Do the request
+    $.post(
+        "home_rotator", 
+        {password: _api_password},
+        function(data){
+            alert("Homing rotator.");
             pause_web_controls();
             setTimeout(resume_web_controls,10000);
         }

--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -332,7 +332,7 @@ function move_rotator(){
 
     // Grab the az/el input
     _az = $('#azimuth-input').val();
-    _el = $('#azimuth-input').val();
+    _el = $('#elevation-input').val();
 
     // Parse to a float.
     _az_float = parseFloat(_az);

--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -139,7 +139,7 @@ function verify_password(){
             if(autorx_config["rotator_enabled"] == true) {
                 $("#rotatorControlForm").show().css("visibility","visible");
             } else {
-                $("#rotatorControlForm").show().css("visibility","hidden");
+                $("#rotatorControlForm").hide().css("visibility","hidden");
             }
         }
     ).fail(function(xhr, status, error){

--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -136,6 +136,11 @@ function verify_password(){
             $("#password-header").html("<h2>Password OK!</h2>");
             $("#password-field").hide().css("visibility", "hidden");
             $("#controls").show().css("visibility", "visible");
+            if(autorx_config["rotator_enabled"] == true) {
+                $("#rotatorControlForm").show().css("visibility","visible");
+            } else {
+                $("#rotatorControlForm").show().css("visibility","hidden");
+            }
         }
     ).fail(function(xhr, status, error){
         // Otherwise, we probably got a 403 error (forbidden) which indicates the password was bad.

--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -81,8 +81,13 @@ function pause_web_controls() {
     $("#disable-scanner").prop('disabled', true);
     $("#frequency-input").prop('disabled', true);
     $("#sonde-type-select").prop('disabled', true);
-    $("#stop-frequency-select").prop('disabled', true);   
+    $("#stop-frequency-select").prop('disabled', true);
+    $("#azimuth-input").prop('disabled', true);
+    $("#elevation-input").prop('disabled', true);
+    $("#move-rotator").prop('disabled', true);
+    $("#home-rotator").prop('disabled', true);
 }
+
 
 function resume_web_controls() {
     $("#verify-password").prop('disabled', false);
@@ -93,7 +98,11 @@ function resume_web_controls() {
     $("#disable-scanner").prop('disabled', false);
     $("#frequency-input").prop('disabled', false);
     $("#sonde-type-select").prop('disabled', false);
-    $("#stop-frequency-select").prop('disabled', false);   
+    $("#stop-frequency-select").prop('disabled', false);
+    $("#azimuth-input").prop('disabled', false);
+    $("#elevation-input").prop('disabled', false);
+    $("#move-rotator").prop('disabled', false);
+    $("#home-rotator").prop('disabled', false);
 }
 
 

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -1690,18 +1690,20 @@
                 <button id="disable-scanner" onclick="disable_scanner();">Disable</button>
             </div>
             <br>
-            <h2>Rotator Control</h2>
-            <p>Go To Position</p>
-            <input style="display:inline;vertical-align:middle;" type="text" id="azimuth-input" placeholder="Azimuth (degrees)">
-            <input style="display:inline;vertical-align:middle;" type="text" id="elevation-input" placeholder="Elevation (degrees)">
-            <div style="display:inline;vertical-align:middle;">
-                <button id="move-rotator" onclick="move_rotator();">Move</button>
+            <div id="rotatorControlForm">
+                <h2>Rotator Control</h2>
+                <p>Go To Position</p>
+                <input style="display:inline;vertical-align:middle;" type="text" id="azimuth-input" placeholder="Azimuth (degrees)">
+                <input style="display:inline;vertical-align:middle;" type="text" id="elevation-input" placeholder="Elevation (degrees)">
+                <div style="display:inline;vertical-align:middle;">
+                    <button id="move-rotator" onclick="move_rotator();">Move</button>
+                </div>
+                <br>
+                <div style="display:inline;vertical-align:middle;">
+                    <button id="home-rotator" onclick="home_rotator();">Home Rotator</button>
+                </div>
+                <br>
             </div>
-            <br>
-            <div style="display:inline;vertical-align:middle;">
-                <button id="home-rotator" onclick="home_rotator();">Home Rotator</button>
-            </div>
-            <br>
           </div>
         </div>
       </div>

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -1689,6 +1689,19 @@
             <div style="display:inline;vertical-align:middle;">
                 <button id="disable-scanner" onclick="disable_scanner();">Disable</button>
             </div>
+            <br>
+            <h2>Rotator Control</h2>
+            <p>Go To Position</p>
+            <input style="display:inline;vertical-align:middle;" type="text" id="azimuth-input" placeholder="Azimuth (degrees)">
+            <input style="display:inline;vertical-align:middle;" type="text" id="elevation-input" placeholder="Elevation (degrees)">
+            <div style="display:inline;vertical-align:middle;">
+                <button id="move-rotator" onclick="move_rotator();">Move</button>
+            </div>
+            <br>
+            <div style="display:inline;vertical-align:middle;">
+                <button id="home-rotator" onclick="home_rotator();">Home Rotator</button>
+            </div>
+            <br>
           </div>
         </div>
       </div>

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -623,11 +623,7 @@ def flask_move_rotator():
 
             logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
 
-            # Find correct exporter and run the move rotator command (there has to be a better way)
-            for exporter in autorx.exporter_objects:
-                if "move_rotator" in dir(exporter):
-                    exporter.move_rotator(_az, _el)
-                    exporter.rotator_homed = False
+            autorx.move_rotator(az=_az, el=_el)
 
             return "OK"
         else:
@@ -653,10 +649,7 @@ def flask_home_rotator():
 
             logging.info("Web - Got rotator home request")
 
-            # Find correct exporter and run the move rotator command (there has to be a better way)
-            for exporter in autorx.exporter_objects:
-                if "home_rotator" in dir(exporter):
-                    exporter.home_rotator()
+            autorx.move_rotator(home=True)
 
             return "OK"
         else:

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -21,6 +21,7 @@ import sys
 import xml.etree.ElementTree as ET
 import autorx
 import autorx.config
+import autorx.rotator
 import autorx.scan
 from autorx.geometry import GenericTrack
 from autorx.utils import check_autorx_versions
@@ -597,6 +598,66 @@ def flask_enable_scanner():
     else:
         abort(403)
 
+
+@app.route("/move_rotator", methods=["POST"])
+def flask_move_rotator():
+    """ Move rotator to target az/el position by injecting telem packet in rotator queue
+    Example:
+    curl -d "az=180&el=15&password=foobar" -X POST http://localhost:5000/move_rotator
+    """
+
+    if request.method == "POST" and autorx.config.global_config["web_control"]:
+        if "password" not in request.form:
+            abort(403)
+
+        if (request.form["password"] == autorx.config.web_password) and (
+            autorx.config.web_password != "none"
+        ):
+
+            try:
+                _az = float(request.form["az"])
+                _el = float(request.form["el"])
+            except Exception as e:
+                logging.error("Web - Error in rotator move request: %s", str(e))
+                abort(500)
+
+            logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
+
+            # autorx.scan_results.put([[_freq, _type]])
+            # autorx.rotator.
+
+            return "OK"
+        else:
+            abort(403)
+
+    else:
+        abort(403)
+
+@app.route("/home_rotator", methods=["POST"])
+def flask_home_rotator():
+    """ Move rotator to target az/el position by injecting telem packet in rotator queue
+    Example:
+    curl -d "password=foobar" -X POST http://localhost:5000/home_rotator
+    """
+
+    if request.method == "POST" and autorx.config.global_config["web_control"]:
+        if "password" not in request.form:
+            abort(403)
+
+        if (request.form["password"] == autorx.config.web_password) and (
+            autorx.config.web_password != "none"
+        ):
+
+            logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
+
+            # autorx.scan_results.put([[_freq, _type]])
+
+            return "OK"
+        else:
+            abort(403)
+
+    else:
+        abort(403)
 
 #
 # SocketIO Events

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -623,8 +623,11 @@ def flask_move_rotator():
 
             logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
 
-            # autorx.scan_results.put([[_freq, _type]])
-            # autorx.rotator.
+            # Find correct exporter and run the move rotator command (there has to be a better way)
+            for exporter in autorx.exporter_objects:
+                if "move_rotator" in dir(exporter):
+                    exporter.move_rotator(_az, _el)
+                    exporter.rotator_homed = False
 
             return "OK"
         else:
@@ -648,9 +651,12 @@ def flask_home_rotator():
             autorx.config.web_password != "none"
         ):
 
-            logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
+            logging.info("Web - Got rotator home request")
 
-            # autorx.scan_results.put([[_freq, _type]])
+            # Find correct exporter and run the move rotator command (there has to be a better way)
+            for exporter in autorx.exporter_objects:
+                if "home_rotator" in dir(exporter):
+                    exporter.home_rotator()
 
             return "OK"
         else:

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -625,7 +625,6 @@ def flask_move_rotator():
 
             if autorx.rotator_object:
                 autorx.rotator_object.move_rotator(_az, _el)
-                autorx.rotator_object.rotator_homed = False
 
             return "OK"
         else:

--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -623,7 +623,9 @@ def flask_move_rotator():
 
             logging.info("Web - Got rotator move request: %f, %f" % (_az, _el))
 
-            autorx.move_rotator(az=_az, el=_el)
+            if autorx.rotator_object:
+                autorx.rotator_object.move_rotator(_az, _el)
+                autorx.rotator_object.rotator_homed = False
 
             return "OK"
         else:
@@ -649,7 +651,8 @@ def flask_home_rotator():
 
             logging.info("Web - Got rotator home request")
 
-            autorx.move_rotator(home=True)
+            if autorx.rotator_object:
+                autorx.rotator_object.home_rotator()
 
             return "OK"
         else:


### PR DESCRIPTION
This PR is to give more control of the rotator to improve the ability to receive one-off radiosondes that aren't otherwise captured in the usual scan process. Things that I have added/changed:

- Add az/el input to web GUI
- Add homing button to web GUI
- Allow manual steering when no radiosonde is being received
  - Only move rotator on new telemetry
  - Only home rotator once

The only part that I have doubts about (in terms of matching the auto_rx architecture) is the change to __init__.py by making a global rotator object. I'm all ears to a better way to achieve these things. 

EDIT: This is currently running on KE5GDB-QTH.