### PR TITLE
Ensure that SSRC values are unique

### DIFF
--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -26,7 +26,7 @@ def ka9q_setup_channel(
         f"--mode iq "
         f"--low {int(sample_rate) / (-2.4)} --high {int(sample_rate) / 2.4} "
         f"--frequency {int(frequency)} "
-        f"--ssrc {int(frequency)} "
+        f"--ssrc {round(frequency / 1000)}01 "
         f"--radio {sdr_hostname}"
     )
 
@@ -71,7 +71,7 @@ def ka9q_close_channel(
         f"--samprate 48000 "
         f"--mode iq "
         f"--frequency 0 "
-        f"--ssrc {int(frequency)} "
+        f"--ssrc {round(frequency / 1000)}01 "
         f"--radio {sdr_hostname}"
     )
 

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -75,7 +75,7 @@ def test_sdr(
             f"tune "
             f"--samprate 48000 --mode iq "
             f"--frequency {int(check_freq)} "
-            f"--ssrc {int(check_freq)}314 "
+            f"--ssrc {round(check_freq / 1000)}02 "
             f"--radio {sdr_hostname}"
         )
 
@@ -112,7 +112,7 @@ def test_sdr(
             f"tune "
             f"--samprate 48000 --mode iq "
             f"--frequency 0 "
-            f"--ssrc {int(check_freq)}314 "
+            f"--ssrc {round(check_freq / 1000)}02 "
             f"--radio {sdr_hostname}"
         )
 
@@ -772,7 +772,7 @@ def get_power_spectrum(
         _timeout_cmd = f"{timeout_cmd()} {integration_time+10} "
         _center_freq = (frequency_start + frequency_stop) / 2
         _bins = ((frequency_stop - frequency_start) / step) + 1 # 3001 for 2.4MHz @ 800Hz bins/steps
-        _ssrc = _center_freq * 1000 + 314
+        _ssrc = f"{round(_center_freq / 1000)}03"
 
         _powers_cmd = (
             f"{_timeout_cmd} {ka9q_powers_path} "


### PR DESCRIPTION
Spectrum scanning doesn't work properly with ka9q-radio because Auto-RX chooses the same RTP SSRC number (which ka9q-radio uses as a channel identifier) for both SDR tests and spectrum scanning. The SSRC value must be a unique 32-bit integer.

Here I've changed the SSRC generation to use the frequency in kHz (rounded to the nearest integer) followed by two digits to indicate the channel type (01 for sonde reception, 02 for SDR tests, 03 for spectrum scanning). I hope this will ensure the uniqueness of SSRC values.