### PR TITLE
Fix SSRC generation for pcmcat command

### DIFF
--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -124,7 +124,7 @@ def ka9q_get_iq_cmd(
     # -2 option was removed sometime in early 2024.
     _cmd = (
         f"pcmcat "
-        f"-s {int(frequency)} "
+        f"-s {round(frequency / 1000)}01 "
         f"{_pcm_host} |"
     )
 


### PR DESCRIPTION
In #929 I forgot to update the code that generates the SSRC value for the pcmcat command, which breaks sonde reception. I've fixed that here.