### PR TITLE
Invalidate map size after updating telemetry table

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -738,6 +738,7 @@
                 }else{
                     $(".tabulator-footer").show();
                 }
+                mymap.invalidateSize();
             }
             // Invalidate map size to fix problems with elements resizing.
             mymap.invalidateSize();


### PR DESCRIPTION
The `updateTelemetryTable` function can change the size of the telemetry table, which in turn changes the size of the map. (This occurs on startup when the table footer is hidden, and again whenever any new sondes appear.) But the function doesn't call `mymap.invalidateSize()`, which leaves the map incorrectly centered, at least on Firefox. (If the browser window is resized, then the map snaps back into place.)

Here I've added `mymap.invalidateSize()` to the end of the function. Although `updateTelemetryTable` is called frequently (at least once per second) I expect that this shouldn't cause performance problems because `invalidateSize` returns quickly if the map has not in fact changed size.