### PR TITLE
Remove scan plot data decimation.

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.0-beta2"
+__version__ = "1.8.0-beta3"
 
 # Global Variables
 

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -20,10 +20,6 @@ from threading import Thread, Lock
 from types import FunctionType, MethodType
 from .utils import (
     detect_peaks,
-    rtlsdr_test,
-    reset_rtlsdr_by_serial,
-    reset_all_rtlsdrs,
-    peak_decimation,
     timeout_cmd
 )
 from .sdr_wrappers import test_sdr, reset_sdr, get_sdr_name, get_sdr_iq_cmd, get_sdr_fm_cmd, get_power_spectrum, shutdown_sdr

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -974,9 +974,8 @@ class SondeScanner(object):
                 raise ValueError("Error getting PSD")
 
             # Update the global scan result
-            (_freq_decimate, _power_decimate) = peak_decimation(freq / 1e6, power, 10)
-            scan_result["freq"] = list(_freq_decimate)
-            scan_result["power"] = list(_power_decimate)
+            scan_result["freq"] = [round(x,6) for x in list(freq/1e6)]
+            scan_result["power"] = [round(x,2) for x in list(power)]
             scan_result["timestamp"] = datetime.datetime.now(datetime.timezone.utc).isoformat()
             scan_result["peak_freq"] = []
             scan_result["peak_lvl"] = []

--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -1076,36 +1076,6 @@ def position_info(listener, balloon):
     }
 
 
-def peak_decimation(freq, power, factor):
-    """ Peak-preserving Decimation.
-
-    Args:
-        freq (list): Frequency Data.
-        power (list): Power data.
-        factor (int): Decimation factor.
-
-    Returns:
-        tuple: (freq, power)
-    """
-
-    _out_len = len(freq) // factor
-
-    _freq_out = []
-    _power_out = []
-
-    try:
-        for i in range(_out_len):
-            _f_slice = freq[i * factor : i * factor + factor]
-            _p_slice = power[i * factor : i * factor + factor]
-
-            _freq_out.append(_f_slice[np.argmax(_p_slice)])
-            _power_out.append(_p_slice.max())
-    except:
-        pass
-
-    return (_freq_out, _power_out)
-
-
 if __name__ == "__main__":
     import sys
 


### PR DESCRIPTION
The data sent to the web interface for the scan plot was being decimated 10x. This looked to be a decision made back in 2018, maybe for performance reasons.

After discussion with @argilo , I've decided to remove this decimation and allow the full resolution data to be seen in the scan plot.

Hopefully this doesn't lead to performance issues! 