### PR TITLE
Remove trailing newline to ensure correct parsing

### DIFF
--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -536,7 +536,7 @@ def read_ka9q_power_log(log_filename, sdr_name):
             continue
 
         # Split line into fields.
-        fields = line.split(",", 5)
+        fields = line.rstrip().split(",", 5)
 
         if len(fields) < 5:
             logging.error(


### PR DESCRIPTION
The `read_ka9q_power_log` function keeps the trailing newline character on each line it reads. Because ka9q-radio's "powers" utility ends lines with a trailing comma (proposed fix: https://github.com/ka9q/ka9q-radio/pull/65), `np.fromstring` interprets the trailing newline character as an invalid value and replaces it with -1. As a result, the list of bin powers is one too long, which causes the frequency range generated by `np.linspace` to be incorrect.

Here I've corrected the problem by removing the trailing newline with `rstrip()`. It is idiomatic to do this when reading lines from a file in Python. After this change, `np.fromstring` ignores powers' trailing comma.

I verified that this change works correctly with or without https://github.com/ka9q/ka9q-radio/pull/65.