### PR TITLE
Work around ka9q-radio powers locale bug

### DIFF
--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -779,6 +779,7 @@ def get_power_spectrum(
         _ssrc = f"{round(_center_freq / 1000)}03"
 
         _powers_cmd = (
+            f"LANG=C " # temporary workaround for https://github.com/ka9q/ka9q-radio/pull/65#issuecomment-2480243690
             f"{_timeout_cmd} {ka9q_powers_path} "
             f"{sdr_hostname} "
             f"-f {_center_freq} "


### PR DESCRIPTION
Fixes #938.

Forcing the C locale when running `powers` will prevent its CSV output from being corrupted.

This workaround can be removed once https://github.com/ka9q/ka9q-radio/pull/65 has been merged and enough time has passed that nobody is running buggy versions.