### PR TITLE
Search for peaks over a wider range

### DIFF
--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -8,6 +8,7 @@
 import autorx
 import datetime
 import logging
+import math
 import numpy as np
 import os
 import sys
@@ -1072,6 +1073,7 @@ class SondeScanner(object):
             # This is actually a bit of a pain to do...
             _peak_freq = []
             _peak_lvl = []
+            _search_radius = math.ceil((self.quantization / 2) / self.search_step)
             for _peak in peak_frequencies:
                 try:
                     # Find the index of the peak within our decimated frequency array.
@@ -1081,13 +1083,13 @@ class SondeScanner(object):
                     # Because we've decimated the freq & power data, the peak location may
                     # not be exactly at this frequency, so we take the maximum of an area
                     # around this location.
-                    _peak_search_min = max(0, _peak_power_idx - 5)
+                    _peak_search_min = max(0, _peak_power_idx - _search_radius)
                     _peak_search_max = min(
-                        len(scan_result["freq"]) - 1, _peak_power_idx + 5
+                        len(scan_result["freq"]) - 1, _peak_power_idx + _search_radius
                     )
                     # Grab the maximum value, and append it and the frequency to the output arrays
                     _peak_lvl.append(
-                        max(scan_result["power"][_peak_search_min:_peak_search_max])
+                        max(scan_result["power"][_peak_search_min:_peak_search_max + 1])
                     )
                     _peak_freq.append(_peak / 1e6)
                 except:


### PR DESCRIPTION
After the removal of scan plot data decimation in #939, some peaks are displayed with incorrect amplitude:

![Screenshot from 2024-11-17 11-30-13](https://github.com/user-attachments/assets/43df664d-01e7-4005-8859-7fb3ba7b6b2d)

This is because the code that searches for the peak amplitude in the bins near the quantized frequency does not search far enough. It only looks from 5 bins down (-4000 Hz) to 4 bins up (+3200 Hz), even though the original peak frequency may be up to 10000/2 = 5000 Hz away.

Here I've solved the problem by calculating the required search radius based on the `quantization` and `search_step` values. I also fixed the off-by-one in the upper limit. (Python ranges do not include the end value.)