### PR TITLE
Turn off transition animations in scan chart

### DIFF
--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -44,6 +44,9 @@ function setup_scan_chart(){
 	scan_chart_obj = c3.generate({
 	    bindto: '#scan_chart',
 	    data: scan_chart_spectra,
+        transition: {
+            duration: 0
+        },
         tooltip: {
             format: {
                 title: function (d) { return (Math.round(d * 1000) / 1000) + " MHz"; },


### PR DESCRIPTION
By default, C3 charts have animated transitions when data is updated. This increases CPU utilization. We can probably do without it in Auto-RX.