### PR TITLE
Explicitly request host byte order in pcmcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 770f988955a0dfb380b71d4cf58529cc6f824e67 && \
+  git checkout 541c15849cbe59694770ca1b2bbad1835ad3667f && \
   make \
     -f Makefile.linux \
     "COPTS=-std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1" \

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -141,6 +141,7 @@ def ka9q_get_iq_cmd(
     _cmd = (
         f"pcmcat "
         f"-s {round(frequency / 1000)}{ssrc} "
+        f"-b 1 "
         f"{_pcm_host} |"
     )
 


### PR DESCRIPTION
As noted in https://github.com/ka9q/ka9q-radio/issues/66, ka9q-radio recently changed pcmcat's behaviour with respect to network-to-host byte order conversions.

Previously, a network-to-host byte order conversion was always performed by default, and could be turned off with the `-b` flag.

Now, network-to-host byte order conversion only occurs by default for two specific RTP types (both having a sample rate of 44100, which Auto-RX does not use), and the `-b` argument takes a parameter: `-b 0` turns off network-to-host byte order conversion, while `-b 1` turns it on.

Because of the change to the `-b` argument, it would be impractical for Auto-RX to support both behaviours. Since Auto-RX expects samples in host byte order, explicitly requesting that with `-b 1` seems wise, even if it means dropping support for older versions of ka9q-radio.

If this change is adopted, we'll need to update the wiki to recommend commit 541c15849cbe59694770ca1b2bbad1835ad3667f (or later) of ka9q-radio. I think it's worth moving forward to this commit, since it includes several bug fixes:

* https://github.com/ka9q/ka9q-radio/pull/63
* https://github.com/ka9q/ka9q-radio/pull/64
* https://github.com/ka9q/ka9q-radio/pull/65