### PR TITLE
Don't prefix KA9Q threads with "SDR:"

### DIFF
--- a/auto_rx/autorx/static/js/autorxapi.js
+++ b/auto_rx/autorx/static/js/autorxapi.js
@@ -11,7 +11,7 @@ function update_task_list(){
 
         for (_task in data){
             // Append the current task to the task list.
-            if(_task.includes("SPY")){
+            if(_task.includes("SPY") || _task.includes("KA9Q")){
                 task_detail = _task + " - "
             }else{
                 task_detail = "SDR:" + _task + " - "


### PR DESCRIPTION
This is a small first step towards making the tasking list smaller.

The "SDR:" prefix added to SDR names seems like it was only intended for RTL-SDR; it's omitted for SpyServer threads. Omitting it for KA9Q threads will save some space.

Before:
![Screenshot from 2024-12-01 22-51-26](https://github.com/user-attachments/assets/9c5bc37f-9019-48f1-9029-2294ae0ab291)

After:
![Screenshot from 2024-12-01 22-52-46](https://github.com/user-attachments/assets/d2d49338-3144-4cdc-ae24-6882d68b68f7)

