### PR TITLE
Invalidate map size when switching to new table page

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -740,6 +740,11 @@
                 }
                 mymap.invalidateSize();
             }
+
+            table.on("pageLoaded", function(pageno) {
+                mymap.invalidateSize();
+            });
+
             // Invalidate map size to fix problems with elements resizing.
             mymap.invalidateSize();
 


### PR DESCRIPTION
When many sondes are displayed in the table, switching between pages can change the height of the table, which subsequently changes the height of the map. In this situation, `invalidateSize()` needs to be called to prevent the map from rendering incorrectly.