### PR TITLE
Reduce vertical size of scan plot

### DIFF
--- a/auto_rx/autorx/static/css/main.css
+++ b/auto_rx/autorx/static/css/main.css
@@ -377,6 +377,11 @@ input:checked + .slider:before {
     color:inherit;
 }
 
+#telem_table {
+    margin-top: 0.25em;
+    margin-bottom: 0.25em;
+}
+
 /* Modal Header */
 .modal-header {
   padding: 2px 16px;

--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -16,6 +16,9 @@ function setup_scan_chart(){
 	        ['x_spectra',autorx_config.min_freq, autorx_config.max_freq],
 	        ['Spectra',0,0]
 	    ],
+		colors: {
+			Spectra: "#2f77b4"
+		},
 	    type:'line'
 	};
 
@@ -27,6 +30,9 @@ function setup_scan_chart(){
 	        ['x_peaks',0],
 	        ['Peaks',0]
 	    ],
+		colors: {
+			Peaks: "#ff7f0e"
+		},
 	    type:'scatter'
 	};
 
@@ -38,6 +44,9 @@ function setup_scan_chart(){
 	        ['x_thresh',autorx_config.min_freq, autorx_config.max_freq],
 	        ['Threshold',autorx_config.snr_threshold,autorx_config.snr_threshold]
 	    ],
+		colors: {
+			Threshold: "#2ca02c"
+		},
 	    type:'line'
 	};
 
@@ -70,6 +79,12 @@ function setup_scan_chart(){
 	            label:"Power (dB - Uncalibrated)"
 	        }
 	    },
+		size: {
+			height: 200
+		},
+		legend: {
+			show: false
+		},
 	    point:{r:10}
 	});
 }

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -1272,7 +1272,7 @@
                     document.getElementById("main").style.marginLeft = "350px";
                     document.getElementById("mySidenav").style.borderRadius = "0px 25px 25px 0px";
                     mymap.invalidateSize();
-                    setTimeout(scan_chart_obj.resize,500);
+                    scan_chart_obj.flush();
                 } else { // Fullsize on mobile.
                     x.style.display = "block";
                     y.style.display = "none";
@@ -1288,7 +1288,7 @@
                 document.getElementById("mySidenav").style.width = 0;
                 document.getElementById("main").style.marginLeft = 0;
                 mymap.invalidateSize();
-                setTimeout(scan_chart_obj.resize,500);
+                scan_chart_obj.flush();
             }
         }
 
@@ -1304,7 +1304,7 @@
                     document.getElementById("main").style.marginRight = "350px";
                     document.getElementById("mySettings").style.borderRadius = "25px 0px 0px 25px";
                     mymap.invalidateSize();
-                    setTimeout(scan_chart_obj.resize,500);
+                    scan_chart_obj.flush();
                     setTimeout(showDown,500);
                 } else { // Fullsize on mobile.
                     y.style.display = "none";
@@ -1319,7 +1319,7 @@
                 document.getElementById("mySettings").style.width = 0;
                 document.getElementById("main").style.marginRight = 0;
                 mymap.invalidateSize();
-                setTimeout(scan_chart_obj.resize,500);
+                scan_chart_obj.flush();
                 setTimeout(showDown,500);
             }
         }
@@ -1355,7 +1355,7 @@
              setCookie("scan", 'true', 365);
              mymap.invalidateSize();
              redraw_scan_chart();
-             setTimeout(scan_chart_obj.resize,500);
+             scan_chart_obj.flush();
            }
         }
 
@@ -1642,7 +1642,6 @@
             <div id="telem_table"></div>
         </div>
         <div id="scanid">
-            <h2>Scan Results</h2>
             <div id='scan_results'>No scan data yet...</div>
             <div id="scan_chart" style="width:100%;"></div>
         </div>


### PR DESCRIPTION
The scan plot takes up quite a lot of precious vertical space. Here I've made it smaller by removing the "Scan Results" heading, reducing the vertical size from 320 pixels (the default) to 200 pixels, and removing the legend.

Before:

![Screenshot from 2024-12-07 18-10-22](https://github.com/user-attachments/assets/f956758c-47d4-4cb9-8b0f-12b4401b6fa7)

After:

![Screenshot from 2024-12-07 18-09-25](https://github.com/user-attachments/assets/09c8c1ef-0c1e-498f-b66d-91dd6454d46c)