### PR TITLE
Update to latest ka9q-radio commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 541c15849cbe59694770ca1b2bbad1835ad3667f && \
+  git checkout ff7fe26a12909317b26bdb24a0576db87c15baf2 && \
   make \
     -f Makefile.linux \
     "COPTS=-std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1" \


### PR DESCRIPTION
This pulls in https://github.com/ka9q/ka9q-radio/pull/71, which gives a nicer-looking scan plot.

I am running this commit on my two stations without issue.