### PR TITLE
Don't redraw scan chart before first scan

### DIFF
--- a/auto_rx/autorx/static/js/scan_chart.js
+++ b/auto_rx/autorx/static/js/scan_chart.js
@@ -91,7 +91,7 @@ function setup_scan_chart(){
 
 function redraw_scan_chart(){
 	// Plot the updated data.
-	if(scan_chart_last_drawn === scan_chart_latest_timestamp){
+	if(!scan_chart_latest_timestamp || scan_chart_last_drawn === scan_chart_latest_timestamp){
 		// No need to re-draw.
 		//console.log("No need to re-draw.");
 		return;


### PR DESCRIPTION
If "Show Scan Plot" is toggled on before the first scan has completed, or the scan plot is open and the user navigates away from the Auto-RX tab and back before the first scan has completed, then an error occurs and the scan plot renders incorrectly:

![Screenshot from 2024-12-12 11-28-47](https://github.com/user-attachments/assets/8b973d3f-b9a9-4397-8b24-7f5f74ed5bee)

![Screenshot from 2024-12-12 11-28-27](https://github.com/user-attachments/assets/e09dc887-58e8-4d36-8ee7-802d741b635b)

This happens because `scan_chart_latest_timestamp` is not defined until the first scan has completed, but `redraw_scan_chart` (which is invoked when the scan chart is opened, or when the user navigates back from another tab) attempts to use it anyway.

To fix the problem, I've added a check so that `redraw_scan_chart` exits early if `scan_chart_latest_timestamp` is not yet defined.