### PR TITLE
v1.8.1-beta2 - KA9Q Channel Filter, RS41/DFM Estimator BW Tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Improvements from the upstream RS codebase will be merged into this codebase whe
 Please consider joining the Google Group to receive updates on new software features:
 https://groups.google.com/forum/#!forum/radiosonde_auto_rx
 
+We also have a channel in the SondeHub Discord server: https://sondehub.org/go/discord
+
 ## Presentations
 * Linux.conf.au 2019 - https://www.youtube.com/watch?v=YBy-bXEWZeM
 * UKHAS Conference 2019 - [Presented via Skype](https://youtu.be/azDJmMywBgw?t=643) which had some audio issues at the start. Slides [here](https://rfhead.net/sondes/auto_rx_presentation_UKHAS2019.pdf).

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.1-beta1"
+__version__ = "1.8.1-beta2"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -829,9 +829,10 @@ class SondeDecoder(object):
             _baud_rate = 4800
             _sample_rate = 48000 # 10x Oversampling
 
-            # Limit FSK estimator window to roughly +/- 10 kHz
-            _lower = -10000
-            _upper = 10000
+            # Limit FSK estimator window to roughly +/- 5 kHz
+            _lower = -5000
+            _upper = 5000
+
 
             demod_cmd = get_sdr_iq_cmd(
                 sdr_type = self.sdr_type,
@@ -844,14 +845,17 @@ class SondeDecoder(object):
                 ppm = self.ppm,
                 gain = self.gain,
                 bias = self.bias,
-                dc_block = True
+                dc_block = True,
+                channel_filter = 5000 # +/- 5 kHz channel filter.
             )
 
             # Add in tee command to save IQ to disk if debugging is enabled.
             if self.save_decode_iq:
                 demod_cmd += f" tee {self.save_decode_iq_path} |"
 
-            demod_cmd += "./fsk_demod --cs16 -b %d -u %d -s --stats=%d 2 %d %d - -" % (
+            # Use a 4800 Hz mask estimator to better avoid adjacent sonde issues.
+            # Also seems to give a small performance bump.
+            demod_cmd += "./fsk_demod --cs16 -b %d -u %d -s --mask 4800 --stats=%d 2 %d %d - -" % (
                 _lower,
                 _upper,
                 _stats_rate,
@@ -949,15 +953,16 @@ class SondeDecoder(object):
             _baud_rate = 2500
             _sample_rate = 50000 # 10x Oversampling
 
-            # Limit FSK estimator window to roughly +/- 10 kHz
-            _lower = -10000
-            _upper = 10000
+            # Limit FSK estimator window to roughly +/- 5 kHz
+            _lower = -5000
+            _upper = 5000
 
-            if (abs(403200000 - self.sonde_freq) < 20000) and (self.sdr_type == "RTLSDR"):
-                # Narrow up the frequency estimator window if we are close to
-                # the 403.2 MHz RTLSDR Spur.
-                _lower = -8000
-                _upper = 8000
+            # Un-necessary.
+            # if (abs(403200000 - self.sonde_freq) < 20000) and (self.sdr_type == "RTLSDR"):
+            #     # Narrow up the frequency estimator window if we are close to
+            #     # the 403.2 MHz RTLSDR Spur.
+            #     _lower = -8000
+            #     _upper = 8000
 
             demod_cmd = get_sdr_iq_cmd(
                 sdr_type = self.sdr_type,
@@ -970,7 +975,8 @@ class SondeDecoder(object):
                 ppm = self.ppm,
                 gain = self.gain,
                 bias = self.bias,
-                dc_block = True
+                dc_block = True,
+                channel_filter = 5000
             )
 
             # Add in tee command to save IQ to disk if debugging is enabled.
@@ -978,6 +984,7 @@ class SondeDecoder(object):
                 demod_cmd += f" tee {self.save_decode_iq_path} |"
 
             # NOTE - Using inverted soft decision outputs, so DFM type detection works correctly.
+            # No mask estimator - DFMs seem to decode better without it!
             demod_cmd += "./fsk_demod --cs16 -b %d -u %d -s -i --stats=%d 2 %d %d - -" % (
                 _lower,
                 _upper,

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -17,7 +17,8 @@ def ka9q_setup_channel(
     sdr_hostname,
     frequency,
     sample_rate,
-    scan
+    scan,
+    channel_filter = None
 ):
     if scan:
         ssrc="04"
@@ -25,12 +26,20 @@ def ka9q_setup_channel(
         ssrc="01"
 
     # tune --samprate 48000 --frequency 404m09 --mode iq --ssrc 404090000 --radio sonde.local
+
+    if channel_filter:
+        _low = int(channel_filter * -1.0)
+        _high = int(channel_filter)
+    else:
+        _low = int(int(sample_rate) / (-2.4))
+        _high = int(int(sample_rate) / 2.4)
+
     _cmd = (
         f"{timeout_cmd()} 5 " # Add a timeout, because connections to non-existing servers block for ages
         f"tune "
         f"--samprate {int(sample_rate)} "
         f"--mode iq "
-        f"--low {int(int(sample_rate) / (-2.4))} --high {int(int(sample_rate) / 2.4)} "
+        f"--low {_low} --high {_high} "
         f"--frequency {int(frequency)} "
         f"--ssrc {round(frequency / 1000)}{ssrc} "
         f"--radio {sdr_hostname}"
@@ -120,7 +129,8 @@ def ka9q_get_iq_cmd(
         sdr_hostname,
         frequency,
         sample_rate,
-        scan
+        scan,
+        channel_filter = None
 ):
     if scan:
         ssrc="04"
@@ -128,7 +138,7 @@ def ka9q_get_iq_cmd(
         ssrc="01"
     
     # We need to setup a channel before we can use it!
-    _setup_success = ka9q_setup_channel(sdr_hostname, frequency, sample_rate, scan)
+    _setup_success = ka9q_setup_channel(sdr_hostname, frequency, sample_rate, scan, channel_filter)
 
     if not _setup_success:
         logging.critical(f"KA9Q ({sdr_hostname}) - Could not setup rx channel! Decoder will likely timeout.")

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -281,7 +281,8 @@ def get_sdr_iq_cmd(
     sdr_hostname = "",
     sdr_port = 5555,
     ss_iq_path = "./ss_iq",
-    scan = False
+    scan = False,
+    channel_filter = None
 ):
     """
     Get a command-line argument to get IQ (signed 16-bit) from a SDR
@@ -303,7 +304,8 @@ def get_sdr_iq_cmd(
     Arguments for KA9Q SDR Server / SpyServer:
     sdr_hostname (str): Hostname of KA9Q Server
     sdr_port (int): Port number of KA9Q Server
-    scan (bool): Create unique SSRC for scan attempts
+    scan (bool): Create unique SSRC for scan attempts (KA9Q Only)
+    channel_filter (int/float): Set a high/lowpass frequency for a KA9Q channel.
 
     Arguments for SpyServer Client:
     ss_iq_path (str): Path to spyserver IQ client utility.
@@ -361,9 +363,9 @@ def get_sdr_iq_cmd(
         return _cmd
     
     if sdr_type == "KA9Q":
-        _cmd = ka9q_get_iq_cmd(sdr_hostname, frequency, sample_rate, scan)
+        _cmd = ka9q_get_iq_cmd(sdr_hostname, frequency, sample_rate, scan, channel_filter)
 
-        if dc_block:
+        if dc_block and ("KA9Q" not in sdr_type):
             _cmd += _dc_remove
 
         return _cmd

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -19,10 +19,9 @@
 #
 # RTLSDR - Use one or more RTLSDRs
 # 
-# EXPERIMENTAL / NOT IMPLEMENTED options:
+# Network SDR Server options:
 # SpyServer - Use an Airspy SpyServer
 # KA9Q - Use a KA9Q-Radio Server 
-# WARNING: These are still under development and may not work correctly.
 #
 sdr_type = RTLSDR
 
@@ -140,7 +139,7 @@ always_decode = []
 # STATION LOCATION #
 ####################
 # Used by the Sondehub Uploader, APRS Uploader, and by Rotator Control
-# Lat/Lon in decimal degrees, altitude in metres.
+# Lat/Lon in decimal degrees, altitude in metres (AMSL).
 # Note: You do not need to specify your home station accurately if you don't want to!
 # Feel free to use a position somewhere near your general area, that doesn't identify your home location.
 #

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -549,8 +549,8 @@ scan_delay = 10
 quantization = 10000
 # Decoder Spacing Limit - Only start a new decoder if it is separated from an existing decoder by at least
 # this value (Hz). This helps avoid issues where a drifting radiosonde is detected on two adjacent channels.
-# If you regularly encounter radiosondes on adjacent (10kHz) channels, then set this value to 5000.
-decoder_spacing_limit = 15000
+# For Network SDR systems, we set this to a lower value than the usual default of 15 kHz, as we have better channel filtering.
+decoder_spacing_limit = 5000
 # Temporary Block Time (minutes) - How long to block encrypted or otherwise non-decodable sondes for.
 temporary_block_time = 120
 # Upload when (seconds_since_utc_epoch%upload_rate) == 0. Otherwise just delay upload_rate seconds between uploads.

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -20,12 +20,11 @@
 #
 # RTLSDR - Use one or more RTLSDRs
 # 
-# EXPERIMENTAL / NOT IMPLEMENTED options:
+# Network SDR Server options:
 # SpyServer - Use an Airspy SpyServer
 # KA9Q - Use a KA9Q-Radio Server 
-# WARNING: These are still under development and may not work correctly.
 #
-sdr_type = SpyServer
+sdr_type = KA9Q
 
 
 #
@@ -38,7 +37,7 @@ sdr_type = SpyServer
 # If SDR type is either KA9Q or SpyServer, this defines the maximum number of parallel
 # decoding/scan tasks. On a RPi 4, ~5 tasks are possible.
 #
-sdr_quantity = 5
+sdr_quantity = 10
 
 
 #
@@ -48,7 +47,7 @@ sdr_quantity = 5
 # Is using KA9Q-Radio, the hostname of the 'radio' server (e.g. sonde.local) needs to be
 # defined, and the port number is unused.
 #
-sdr_hostname = localhost
+sdr_hostname = sonde.local
 sdr_port = 5555
 
 #
@@ -141,7 +140,7 @@ always_decode = []
 # STATION LOCATION #
 ####################
 # Used by the Sondehub Uploader, APRS Uploader, and by Rotator Control
-# Lat/Lon in decimal degrees, altitude in metres.
+# Lat/Lon in decimal degrees, altitude in metres (AMSL).
 # Note: You do not need to specify your home station accurately if you don't want to!
 # Feel free to use a position somewhere near your general area, that doesn't identify your home location.
 #


### PR DESCRIPTION
Some possible performance impacting changes in this one.
* get_sdr_iq_command function now accepts an optional channel_filter argument. This gets passed to the KA9Q channel setup, allowing bandpass filtering. We should look to see if this can be implemented for other SDR types.
* DC blocking is disabled for KA9Q setups. It doesn't look to be required. 

In response to an issue observed by @argilo where a DFM and RS41 are regularly seen only 10 kHz apart, I've made the following changes:

* RS41:
  * Estimator range has been narrowed to +/- 5 kHz, and a +/- 5 kHz channel filter is enabled for KA9Q setups.
  * fsk_demod is set to use a mask estimator, with a tone spacing of 4800 Hz.
* DFM:
  * Estimator range has been narrowed to +/- 5 kHz, and a +/- 5 kHz channel filter is enabled for KA9Q setups.
  * This *should* be fine for DFM17 sondes. However, there is a possibility that DFM09s may drift outside of this window. Need to evaluate this in the wild.

We should look into the validity of the current estimator ranges for other sonde types, and whether the mask estimator adds any performance improvement.

Some testing data of mask estimator vs no mask estimator:

**RS41 - No Mask Estimator**
```
rs41_96k_float_08.0dB.bin, 0, 1.739
rs41_96k_float_08.5dB.bin, 0, 1.385
rs41_96k_float_09.0dB.bin, 0, 1.944
rs41_96k_float_09.5dB.bin, 21, 1.813
rs41_96k_float_10.0dB.bin, 56, 1.928
rs41_96k_float_10.5dB.bin, 78, 3.035
rs41_96k_float_11.0dB.bin, 76, 2.458
rs41_96k_float_11.5dB.bin, 94, 3.305
```
**RS41 - 4800 Hz Mask Estimator**
```
rs41_96k_float_08.0dB.bin, 0, 2.111
rs41_96k_float_08.5dB.bin, 0, 2.322
rs41_96k_float_09.0dB.bin, 3, 2.053
rs41_96k_float_09.5dB.bin, 54, 2.467
rs41_96k_float_10.0dB.bin, 103, 2.297
rs41_96k_float_10.5dB.bin, 115, 2.283
rs41_96k_float_11.0dB.bin, 110, 2.367
rs41_96k_float_11.5dB.bin, 116, 2.317
```
(Approx 0.5 dB improvement)

**DFM - No Mask Estimator**
```
dfm09_96k_float_05.0dB.bin, 0, 2.591
dfm09_96k_float_05.5dB.bin, 0, 2.957
dfm09_96k_float_06.0dB.bin, 5, 2.097
dfm09_96k_float_06.5dB.bin, 24, 2.181
dfm09_96k_float_07.0dB.bin, 59, 1.805
dfm09_96k_float_07.5dB.bin, 71, 2.033
dfm09_96k_float_08.0dB.bin, 88, 2.446
dfm09_96k_float_08.5dB.bin, 90, 2.353
```

**DFM - 5080 Hz Mask Estimator**
```
dfm09_96k_float_05.0dB.bin, 0, 2.073
dfm09_96k_float_05.5dB.bin, 0, 2.367
dfm09_96k_float_06.0dB.bin, 1, 2.539
dfm09_96k_float_06.5dB.bin, 14, 2.082
dfm09_96k_float_07.0dB.bin, 55, 2.229
dfm09_96k_float_07.5dB.bin, 64, 2.099
dfm09_96k_float_08.0dB.bin, 85, 2.447
```
(Not really any performance gain in this case, maybe a slight degradation)
