### PR TITLE
Use pcmrecord instead of pcmcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,11 +61,11 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout ff7fe26a12909317b26bdb24a0576db87c15baf2 && \
+  git checkout 08142683dbc398087a5b7d384b1a36bb24b1eca3 && \
   make \
     -f Makefile.linux \
     "COPTS=-std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1" \
-    tune powers pcmcat
+    tune powers pcmrecord
 
 # Copy in radiosonde_auto_rx.
 COPY . /root/radiosonde_auto_rx
@@ -118,7 +118,7 @@ RUN ln -s ss_client /opt/auto_rx/ss_iq && \
 # Copy ka9q-radio utilities 
 COPY --from=build /root/ka9q-radio/tune /usr/local/bin/
 COPY --from=build /root/ka9q-radio/powers /usr/local/bin/
-COPY --from=build /root/ka9q-radio/pcmcat /usr/local/bin/
+COPY --from=build /root/ka9q-radio/pcmrecord /usr/local/bin/
 
 # Allow mDNS resolution for ka9q-radio utilities
 RUN sed -i -e 's/files dns/files mdns4_minimal [NOTFOUND=return] dns/g' /etc/nsswitch.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN apt-get update && \
     libbsd-dev \
     libfftw3-dev \
     libiniparser-dev \
+    libogg-dev \
     libopus-dev && \
   rm -rf /var/lib/apt/lists/*
 

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -146,12 +146,13 @@ def ka9q_get_iq_cmd(
     # Get the 'PCM' version of the server name, where as assume -pcm is added to the first part of the hostname.
     _pcm_host = sdr_hostname.split('.')[0] + "-pcm." + ".".join(sdr_hostname.split(".")[1:])
 
-    # Example: pcmcat -s 404090000 sonde-pcm.local
+    # Example: pcmrecord --ssrc 404090001 --catmode --raw sonde-pcm.local
     # -2 option was removed sometime in early 2024.
     _cmd = (
-        f"pcmcat "
-        f"-s {round(frequency / 1000)}{ssrc} "
-        f"-b 1 "
+        f"pcmrecord "
+        f"--ssrc {round(frequency / 1000)}{ssrc} "
+        f"--catmode "
+        f"--raw "
         f"{_pcm_host} |"
     )
 

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -781,7 +781,6 @@ def get_power_spectrum(
         _ssrc = f"{round(_center_freq / 1000)}03"
 
         _powers_cmd = (
-            f"LANG=C " # temporary workaround for https://github.com/ka9q/ka9q-radio/pull/65#issuecomment-2480243690
             f"{_timeout_cmd} {ka9q_powers_path} "
             f"{sdr_hostname} "
             f"-f {_center_freq} "

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -60,8 +60,8 @@ def test_sdr(
         # if not os.path.isfile('tune'):
         #     logging.critical("Could not find KA9Q-Radio 'tune' binary! This may need to be compiled and installed.")
         #     return False
-        # if not os.path.isfile('pcmcat'):
-        #     logging.critical("Could not find KA9Q-Radio 'pcmcat' binary! This may need to be compiled and installed.")
+        # if not os.path.isfile('pcmrecord'):
+        #     logging.critical("Could not find KA9Q-Radio 'pcmrecord' binary! This may need to be compiled and installed.")
         #     return False
         # TBD - whatever we need for spectrum use.
         # if not os.path.isfile('TBD'):


### PR DESCRIPTION
As noted in https://github.com/ka9q/ka9q-radio/issues/66#issuecomment-2552692572, @ka9q has merged pcmcat's functionality into pcmrecord, and pcmcat may be removed or converted to a shell script. Here I've switched over to using pcmrecord, and this is working well on my test station.

Since the required pcmrecord functionality is only available in recent commits, the wiki will need to be updated to recommend a newer commit. (I've tested with 08142683dbc398087a5b7d384b1a36bb24b1eca3).

Since a new commit is required, there's no reason to keep the workaround for the powers bug (#941) so I've reverted it here.