### PR TITLE
Narrow detection bandwidth to avoid adjacent-channel interference

### DIFF
--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -288,13 +288,7 @@ def detect_sonde(
             _if_bw = 64
         else:
             _iq_bw = 48000
-            _if_bw = 20
-
-            # Try and avoid the RTLSDR 403.2 MHz spur.
-            # Note that this is only goign to work if we are detecting on 403.210 or 403.190 MHz.
-            if (abs(403200000 - frequency) < 20000) and (sdr_type == "RTLSDR"):
-                logging.debug("Scanner - Narrowing detection IF BW to avoid RTLSDR spur.")
-                _if_bw = 15
+            _if_bw = 15
         
     else:
         # 1680 MHz sondes


### PR DESCRIPTION
Sonde detection fails in the presence of adjacent-channel interference from another sonde. This happens frequently at my receiving station, where launches from Buffalo, NY are heard on 403.800 MHz, and launches from Wilmington, OH are heard on 403.810 MHz. Narrowing the detection bandwidth to 15 kHz solves the problem.

This change also makes the exception for the RTL-SDR's 403.200 MHz spur unnecessary, so I have removed it.