### PR TITLE
v1.8.1-beta5 - Narrowed detection bandwidth (20 kHz -> 15 kHz)

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.1-beta4"
+__version__ = "1.8.1-beta5"
 
 # Global Variables
 


### PR DESCRIPTION
Detection bandwidth narrowed after testing from @argilo shows this resolved adjacent channel sonde issues. 
