### PR TITLE
Specify image sizes in img tag

### DIFF
--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -507,12 +507,12 @@
                         _sondehub_id = _cell_data.id.replace(/^(DFM|M10|M20|IMET|IMET5|IMET54|MRZ|IMS100|RS11G|MTS01|WXR)-/,"");
 
                         // Add Sondehub Link
-                        _id += "&nbsp;<a href='http://sondehub.org/" + _sondehub_id + "' title='View on Sondehub' target='_blank'>" + "<img src='{{ url_for('static', filename='img/sondehub.png')}}'/>" + "</a>";
+                        _id += "&nbsp;<a href='http://sondehub.org/" + _sondehub_id + "' title='View on Sondehub' target='_blank'>" + "<img src='{{ url_for('static', filename='img/sondehub.png')}}' width='14' height='16'/>" + "</a>";
 
                         // Add Radiosondy Link
                         if(_cell_data.aprsid != null){
                             _aprs_id = _cell_data.aprsid.trim();
-                            _id += "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + _aprs_id + "' title='View on Radiosondy.info' target='_blank'>" + "<img src='{{ url_for('static', filename='img/radiosondy.png')}}'/>" + "</a>";
+                            _id += "<a href='https://radiosondy.info/sonde_archive.php?sondenumber=" + _aprs_id + "' title='View on Radiosondy.info' target='_blank'>" + "<img src='{{ url_for('static', filename='img/radiosondy.png')}}' width='17' height='16'/>" + "</a>";
 
                         } else {
                             _aprs_id = null;


### PR DESCRIPTION
The telemetry table often displays with a scrollbar when initially loaded, partially obscuring the final row:

![Screenshot from 2025-01-11 21-05-23](https://github.com/user-attachments/assets/52552177-0ab3-4490-aff1-aeb81d3a9b41)

Resizing the browser window causes the table to snap back to the correct height.

The problem occurs because the SondeHub and Radiosondy icons are not loaded until after the table is rendered. They are large enough to cause the table rows to expand. Adding explicit `height` and `width` attributes allows the browser to determine the final cell size before the images are loaded. The telemetry table then renders correctly on the initial page load:

![Screenshot from 2025-01-11 21-09-18](https://github.com/user-attachments/assets/5a6231e8-dd3d-4155-8319-80c77da5548f)

