### PR TITLE
Use qemu8 for builds

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@v3
+        with:
+          image: tonistiigi/binfmt:qemu-v8.1.5
 
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Should workaround the random crashes during build on arm64. See https://github.com/tonistiigi/binfmt/issues/215.