### PR TITLE
1.8.1-beta6 - RS41 X-Series Preliminary Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 08142683dbc398087a5b7d384b1a36bb24b1eca3 && \
+  git checkout 21f7f9a70e619ca88394ff1ca86de7482340232f && \
   make \
     -f Makefile.linux \
     "COPTS=-std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 21f7f9a70e619ca88394ff1ca86de7482340232f && \
+  git checkout 08142683dbc398087a5b7d384b1a36bb24b1eca3 && \
   make \
     -f Makefile.linux \
     "COPTS=-std=gnu11 -pthread -Wall -funsafe-math-optimizations -fno-math-errno -fcx-limited-range -D_GNU_SOURCE=1" \

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.1-beta5"
+__version__ = "1.8.1-beta6"
 
 # Global Variables
 


### PR DESCRIPTION
- Re-based RS41 decoder to latest from https://github.com/rs1729/RS
- Added in rdz_ttgo bitfield approach for numSV extraction from the new 0x83 block as a starting point. 

**This numSV decoding approach may not be correct, and more work needs to go into properly deciphering this block. This release is aimed at enabling users to track and recover these new RS41s so further analysis can be performed.**