### PR TITLE
v1.8.1-beta7 - Rebase RS41 and M20 demodulators to rs1729 latest testing

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.1-beta6"
+__version__ = "1.8.1-beta7"
 
 # Global Variables
 


### PR DESCRIPTION
- Updates to RS41 and M20 decoders from rs1729
- M20 Demodulator has better handling of some less common M20 serial numbers
- RS41 demod now uses an updated numSV count technique for the newer block format. numSV counts will be higher, as we are now expecting the sonde to be using multiple GNSS constellations.
- Recommended ka9q-radio commit is now 854ef7510a125a95312dabc285c1ba8371f675f2