### PR TITLE
Update to latest ka9q-radio commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 854ef7510a125a95312dabc285c1ba8371f675f2 && \
+  git checkout ca8c687479b8aa965e749ec2a365ce41ba50f96b && \
   make \
     -f Makefile.linux \
     ARCHOPTS= \


### PR DESCRIPTION
A recent ka9q-radio bug causes diagnostic messages to be printed into pcmrecord's output, corrupting the signal output: https://github.com/ka9q/ka9q-radio/issues/113

This situation occurs if multicast is not enabled on the loopback interface. It is off by default on Linux, but radiod enables it as long as it has the `cap_net_admin` capability. ka9q-radio gives radiod this capability in its installer (https://github.com/ka9q/ka9q-radio/blob/ca8c687479b8aa965e749ec2a365ce41ba50f96b/Makefile.linux#L86) but a containerized ka9q-radio might not have the capability.

The bug was introduced in https://github.com/ka9q/ka9q-radio/commit/231d020d3082862257796b0a6acd4e6e1efcc523 and fixed in https://github.com/ka9q/ka9q-radio/commit/0bb4d297c3ed40ac4f97a6e5233d02e5063886e8.

I think we should update to the latest ka9q-radio to pick up the fix.

This will also be a good commit to recommend in the wiki, since it also fixes undefined behaviour in radiod's startup routine: https://github.com/ka9q/ka9q-radio/issues/111. But ka9q-radio's makefile no longer builds pcmcat by default, so we shouldn't recommend this in the wiki until 1.8.1 is out.