### PR TITLE
Add IMETWIDE sonde type

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -738,7 +738,7 @@ def main():
         "--type",
         type=str,
         default=None,
-        help="Immediately start a decoder for a provided sonde type (Valid Types: RS41, RS92, DFM, M10, M20, IMET, IMET5, LMS6, MK2LMS, MEISEI, MRZ)",
+        help="Immediately start a decoder for a provided sonde type (Valid Types: RS41, RS92, DFM, M10, M20, IMET, IMETWIDE, IMET5, LMS6, MK2LMS, MEISEI, MRZ)",
     )
     parser.add_argument(
         "-t",

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta1"
+__version__ = "1.8.2-beta2"
 
 # Global Variables
 

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -433,6 +433,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
             "MRZ": False,  # .... except for the MRZ, until we know it works.
             "WXR301": True,
             "WXRPN9": True,
+            "IMETWIDE": False,
             "UDP": False,
         }
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -41,7 +41,8 @@ VALID_SONDE_TYPES = [
     "MTS01",
     "UDP",
     "WXR301",
-    "WXRPN9"
+    "WXRPN9",
+    "IMETWIDE"
 ]
 
 # Known 'Drifty' Radiosonde types
@@ -122,7 +123,8 @@ class SondeDecoder(object):
         "MTS01",
         "UDP",
         "WXR301",
-        "WXRPN9"
+        "WXRPN9",
+        "IMETWIDE"
     ]
 
     def __init__(
@@ -561,6 +563,34 @@ class SondeDecoder(object):
 
             # iMet-4 (IMET1RS) decoder
             decode_cmd += f"./imet4iq --iq 0.0 --lpIQ --dc - {_sample_rate} 16 --json {_wideband} 2>/dev/null"
+
+        elif self.sonde_type == "IMETWIDE":
+            # iMet-1/ 4 Sondes, Forced wideband decode version.
+
+            # Set sonde type back to IMET so other iMet-specific handling actions work.
+            self.sonde_type = "IMET"
+
+            _sample_rate = 96000
+
+            decode_cmd = get_sdr_iq_cmd(
+                sdr_type = self.sdr_type,
+                frequency = self.sonde_freq,
+                sample_rate = _sample_rate,
+                sdr_hostname = self.sdr_hostname,
+                sdr_port = self.sdr_port,
+                ss_iq_path = self.ss_iq_path,
+                rtl_device_idx = self.rtl_device_idx,
+                ppm = self.ppm,
+                gain = self.gain,
+                bias = self.bias
+            )
+
+            # Add in tee command to save audio to disk if debugging is enabled.
+            if self.save_decode_iq:
+                decode_cmd += f" tee {self.save_decode_iq_path} |"
+
+            # iMet-4 (IMET1RS) decoder
+            decode_cmd += f"./imet4iq --iq 0.0 --lpIQ --dc - {_sample_rate} 16 --json --imet1 2>/dev/null"
 
         elif self.sonde_type == "IMET5":
             # iMet-54 Sondes

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -1639,6 +1639,7 @@
                 <option value="LMS6">LMS6 (400 MHz)</option>
                 <option value="MK2LMS">LMS6 (1680 MHz)</option>
                 <option value="IMET">iMet-4</option>
+                <option value="IMETWIDE">iMet-1/4 Wideband</option>
                 <option value="IMET5">iMet-50/54</option>
                 <option value="MEISEI">iMS-100</option>
                 <option value="MRZ">MRZ-H1</option>

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -131,7 +131,7 @@ always_scan = []
 
 # always_decode - Always-running decoders. Only possible in a multi-SDR (or network-based SDR) system.
 # List must be in the form: [[401.5,"RS41"], [402.5,"DFM"], [400.5,"M10"], [400.5,"IMET"]]
-# Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01
+# Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMETWIDE, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01
 always_decode = []
 
 

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -133,7 +133,7 @@ always_scan = []
 
 # always_decode - Always-running decoders. Only possible in a multi-SDR (or network-based SDR) system.
 # List must be in the form: [[401.5,"RS41"], [402.5,"DFM"], [400.5,"M10"], [400.5,"IMET"]]
-# Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01
+# Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMETWIDE, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01
 always_decode = []
 
 ####################


### PR DESCRIPTION
Add IMETWIDE sonde type, to allow users to force a wideband imet decoder to be started, either using the web interface, or the always_decode functions.

Note - I think i need to remove all the regular vs experimental decode chain business in decode.py. It's no longer required, and just serves to add confusion when adding decoder entreis.