### PR TITLE
v1.8.2-beta3 Better handling of timeouts when using ka9q-radio and spyserver.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout 4025a34db6e88dce87b8f67c7eb9cc339b920261 && \
+  git checkout 82e3f73f3bddb81740d0e4b22a1cb30dba46309e && \
   make \
     -f Makefile.linux \
     ARCHOPTS= \

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta2"
+__version__ = "1.8.2-beta3"
 
 # Global Variables
 

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -840,7 +840,7 @@ class SondeScanner(object):
             # If we have hit the maximum number of permissable errors, quit.
             if self.error_retries > self.SONDE_SCANNER_MAX_ERRORS:
                 self.log_error(
-                    "Exceeded maximum number of consecutive RTLSDR errors. Closing scan thread."
+                    "Exceeded maximum number of consecutive SDR errors. Closing scan thread."
                 )
                 break
 


### PR DESCRIPTION
SDRs are no longer removed from the SDR list when using KA9Q-Radio or SpyServer. Instead, auto_rx will continue to retry connections forever, emitting error log messages. Behaviour for RTLSDRs should be unchanged.

auto_rx seems to recover OK, at least for KA9Q-radio. Untested for Spyserver.

Recommended ka9q-radio version is now 82e3f73f3bddb81740d0e4b22a1cb30dba46309e , as this correctly times out when samples stop being received.