### PR TITLE
Fix a crash when command line tools are missing

### DIFF
--- a/auto_rx/autorx/utils.py
+++ b/auto_rx/autorx/utils.py
@@ -20,6 +20,7 @@ import time
 import numpy as np
 import semver
 import shutil
+import sys
 from dateutil.parser import parse
 from datetime import datetime, timedelta
 from math import radians, degrees, sin, cos, atan2, sqrt, pi


### PR DESCRIPTION
This fixes a small crash I found when I installed auto_rx on my Mac.

If gtimeout is not installed, `sys.exit(1)` is called from auto_rx/autorx/utils.py, and this file does not import sys. The program does exit, but not gracefully as you can see:

```
2025-03-31 20:25:57,728 CRITICAL:timeout command-line tool not present in system. try installing gtimeout.
Traceback (most recent call last):
  File "<...>/radiosonde_auto_rx/auto_rx/auto_rx.py", line 1102, in <module>
    main()
  File "<...>/radiosonde_auto_rx/auto_rx/auto_rx.py", line 833, in main
    if not check_rs_utils(config):
           ^^^^^^^^^^^^^^^^^^^^^^
  File "<...>/radiosonde_auto_rx/auto_rx/autorx/utils.py", line 74, in check_rs_utils
    _ = timeout_cmd()
        ^^^^^^^^^^^^^
  File "<...>/radiosonde_auto_rx/auto_rx/autorx/utils.py", line 61, in timeout_cmd
    sys.exit(1)
    ^^^
NameError: name 'sys' is not defined. Did you forget to import 'sys'
Main Loop Error - name 'sys' is not defined
```

This small PR adds the missing sys import, and lets the program exit gracefully.
