### PR TITLE
fix CORS support for reverse web proxy deployments

### DIFF
--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -38,6 +38,7 @@ from queue import Queue
 from threading import Thread
 import flask
 from flask import request, abort, make_response, send_file
+from flask_cors import CORS
 from flask_socketio import SocketIO
 from werkzeug.middleware.proxy_fix import ProxyFix
 
@@ -56,9 +57,10 @@ app.jinja_env.auto_reload = True
 flask_app_thread = None
 # A key that needs to be matched to allow shutdown.
 flask_shutdown_key = None
-
+# allow all CORS:
+cors = CORS(app, resources={r"/*": {"origins": "*"}})
 # SocketIO instance
-socketio = SocketIO(app, async_mode="threading")
+socketio = SocketIO(app, async_mode="threading", cors_allowed_origins="*")
 
 # Global store of telemetry data, which we will add data to and manage.
 # Under each key (which will be the sonde ID), we will have a dictionary containing:

--- a/auto_rx/requirements.txt
+++ b/auto_rx/requirements.txt
@@ -1,6 +1,7 @@
 python-dateutil
 flask
 flask-socketio
+flask-cors
 numpy
 requests
 semver


### PR DESCRIPTION
This fixes CORS support for use with SSL via reverse web proxies (like `nginx`) (further: "rwp") for container deployments. The fix was tested both via a rwp, as well as directly to ensure it doesn't break any non-webproxy deployments.

Specifically, it adds the Python flask-cors module to the container and applies CORS enhancements to the creation of the app and the socketio.

This fix does NOT fix the issue/complexity of having websockets work via a rwp -- the transport mechanism will fall back to http(s) polling. However, this works fine.

How to test --
1. A radiosonde_auto_rx container using reverse-web-proxy with this fix has been deployed to <https://kx1t.com/trenton-sonde>
2. The rwp deployed at kx1t.com uses `nginx` with the following `location` definition (and radiosonde_auto_rx is deployed at http://10.244.95.84:88/):
```config
location /trenton-sonde/ {
    proxy_pass http://10.244.95.84:88/;
    proxy_http_version 1.1;
    proxy_redirect / /trenton-sonde/;
    proxy_set_header  X-Forwarded-Prefix /trenton-sonde;
}
```
3. I tested the rwp deployment listed in (1) as well as the direct deployment to <http://10.244.95.84:88>; via the rwp, socketio uses polling; using the direct link, socketio uses websockets. In both cases, the application works equally well.

Last -- I additionally tested the enhancement that was suggested in https://github.com/projecthorus/radiosonde_auto_rx/issues/834 to change` app.wsgi_app` in web.py to:
```python
app.wsgi_app = ProxyFix(app.wsgi_app, x_for=2, x_port=2, x_host=2, x_proto=2, x_prefix=2)
```
Unfortunately, that completely breaks socketio connections - the app works fine with the current code around `app.wsgi_app`