### PR TITLE
v1.8.2-beta5 - Use inverted soft-in for RD91, tweak RS41 demod parameters.

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta4"
+__version__ = "1.8.2-beta5"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -885,9 +885,9 @@ class SondeDecoder(object):
             if self.save_decode_iq:
                 demod_cmd += f" tee {self.save_decode_iq_path} |"
 
-            # Use a 4800 Hz mask estimator to better avoid adjacent sonde issues.
-            # Also seems to give a small performance bump.
-            demod_cmd += "./fsk_demod --cs16 -b %d -u %d -s --mask 4800 --stats=%d 2 %d %d - -" % (
+            # Updated 2025-08-26 to bump mask estimator to 5000 Hz, increase timing estimator duration, and change oversampling rate
+            # From controlled testing this seems to improve weak signal performance.
+            demod_cmd += "./fsk_demod --cs16 -b %d -u %d -s --mask 5000 --nsym=300 -p 5 --stats=%d 2 %d %d - -" % (
                 _lower,
                 _upper,
                 _stats_rate,
@@ -1015,7 +1015,7 @@ class SondeDecoder(object):
             )
 
             decode_cmd = (
-                "./rd94rd41drop --json --softin 2>/dev/null"
+                "./rd94rd41drop --json --softinv 2>/dev/null"
             )
 
             # RD94/RD41s transmit continuously - average over the last 2 frames, and use a mean


### PR DESCRIPTION
RD41 decoder needed to have --softinv option used (based on a recording from an actual RD41). Still unsure how this will go in the wild, but let's see.

From some testing by Stefan HB9TMC, we're applying some tweaks to the RS41 fsk_demod parameters.

Previous settings (--mask=4800, with default oversampling setting of 10):
```
rs41_96k_float_07.5dB.bin, 0, 0.674
rs41_96k_float_08.0dB.bin, 0, 0.676
rs41_96k_float_08.5dB.bin, 0, 0.697
rs41_96k_float_09.0dB.bin, 3, 0.681
rs41_96k_float_09.5dB.bin, 54, 0.673
rs41_96k_float_10.0dB.bin, 103, 0.662
rs41_96k_float_10.5dB.bin, 115, 0.706
rs41_96k_float_11.0dB.bin, 110, 0.673
rs41_96k_float_11.5dB.bin, 116, 0.744
rs41_96k_float_12.0dB.bin, 118, 0.675
```

New settings (--mask=5000 --nsym=300 -p 5):
```
rs41_96k_float_07.0dB.bin, 0, 0.975
rs41_96k_float_07.5dB.bin, 0, 0.910
rs41_96k_float_08.0dB.bin, 0, 1.173
rs41_96k_float_08.5dB.bin, 1, 0.842
rs41_96k_float_09.0dB.bin, 32, 0.906
rs41_96k_float_09.5dB.bin, 100, 0.922
rs41_96k_float_10.0dB.bin, 118, 0.984
rs41_96k_float_10.5dB.bin, 118, 0.823
rs41_96k_float_11.0dB.bin, 118, 0.988
rs41_96k_float_11.5dB.bin, 118, 1.035
rs41_96k_float_12.0dB.bin, 118, 0.851
```
So maybe 0.5 dB improvement, possibly a small hit in CPU usage. Let's give it a go.