### PR TITLE
v1.8.2-beta6 - Add serial number check for dropsondes.

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -668,12 +668,19 @@ def telemetry_filter(telemetry):
     else:
         mrz_callsign_valid = False
 
+    # Dropsonde checks - filter out uninitialised dropsondes (all zero serial - 000000000)
+    if "RD41" in telemetry['type'] or "RD94" in telemetry["type"]:
+        dropsonde_callsign_valid = _serial != "000000000"
+    else:
+        dropsonde_callsign_valid = False
+
     # If Vaisala or DFMs, check the callsigns are valid. If M10/M20, iMet, MTS01 or LMS6, just pass it through - we get callsigns immediately and reliably from these.
     if (
         vaisala_callsign_valid
         or dfm_callsign_valid
         or meisei_callsign_valid
         or mrz_callsign_valid
+        or dropsonde_callsign_valid
         or ("M10" in telemetry["type"])
         or ("M20" in telemetry["type"])
         or ("LMS" in telemetry["type"])
@@ -690,6 +697,9 @@ def telemetry_filter(telemetry):
 
         if "MRZ" in telemetry["id"]:
             _id_msg += " Note: MRZ sondes may take a while to get an ID."
+
+        if "RD41" in telemetry["type"] or "RD94" in telemetry["type"]:
+            _id_msg += " Note: This may be an uninitialised dropsonde."
 
         logging.warning(_id_msg)
         return False

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta5"
+__version__ = "1.8.2-beta6"
 
 # Global Variables
 

--- a/auto_rx/test/test_demod.py
+++ b/auto_rx/test/test_demod.py
@@ -217,6 +217,17 @@ processing_type = {
         "post_process" : " | grep frame | wc -l",
         'files' : "./generated/rs41*"
     },
+    'rs41_fsk_demod_soft_centre_optimised': {
+        # Tweaking some of the modem parameters for a little bit more performance
+        # Keep signal centred.
+        'demod' : "| csdr convert_f_s16 | ./tsrc - - 0.500 |  ../fsk_demod --cs16 -b -10000 -u 10000 -s --nsym=300 -p 5 --mask 4800 --stats=5 2 48000 4800 - - 2>stats.txt |",
+
+        # Decode using rs41ecc
+        'decode': "../rs41mod --ecc --ptu --crc --softin -i --json 2>/dev/null",
+        # Count the number of telemetry lines.
+        "post_process" : " | grep frame | wc -l",
+        'files' : "./generated/rs41*"
+    },
     # RS92 Decoding
     'rs92_fsk_demod_soft': {
         # Shift up to ~24 khz, and then pass into fsk_demod.


### PR DESCRIPTION
Just check that the dropsonde serial number is not all zeros. Best info we have right now...