### PR TITLE
Update leaflet-providers.js - Use preferred tile.openstreetmap.org URL

### DIFF
--- a/auto_rx/autorx/static/js/leaflet-providers.js
+++ b/auto_rx/autorx/static/js/leaflet-providers.js
@@ -77,7 +77,7 @@
 
 	L.TileLayer.Provider.providers = {
 		OpenStreetMap: {
-			url: 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			url: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				maxZoom: 19,
 				attribution:


### PR DESCRIPTION
See https://github.com/openstreetmap/operations/issues/737