### PR TITLE
Attempt to fix possible causes of async hangups w/out logs

### DIFF
--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -49,8 +49,14 @@ def ka9q_setup_channel(
 
     try:
         _output = subprocess.check_output(
-            _cmd, shell=True, stderr=subprocess.STDOUT
+            _cmd, shell=True, stderr=subprocess.STDOUT, timeout=10
         )
+    except subprocess.TimeoutExpired:
+        logging.critical(
+            f"KA9Q ({sdr_hostname}) - tune call timed out while opening channel (Python timeout). "
+            "This indicates the subprocess.check_output call itself hung."
+        )
+        return False
     except subprocess.CalledProcessError as e:
         # Something went wrong...
 
@@ -99,8 +105,14 @@ def ka9q_close_channel(
 
     try:
         _output = subprocess.check_output(
-            _cmd, shell=True, stderr=subprocess.STDOUT
+            _cmd, shell=True, stderr=subprocess.STDOUT, timeout=10
         )
+    except subprocess.TimeoutExpired:
+        logging.critical(
+            f"KA9Q ({sdr_hostname}) - tune call timed out while closing channel (Python timeout). "
+            "This indicates the subprocess.check_output call itself hung."
+        )
+        return False
     except subprocess.CalledProcessError as e:
         # Something went wrong...
 


### PR DESCRIPTION
The async cleanup code was using a shared lock that caused all concurrent scans to wait for each other. This may eventually deadlock the scanner after a few cycles.

Ref: https://github.com/projecthorus/radiosonde_auto_rx/pull/1026#issuecomment-3542190707

  Fixed:
  - Removed unnecessary lock from async cleanup (each frequency has unique SSRC anyway)
  - Added subprocess timeouts to prevent hangs
  - Fixed fallback logic so sequential scanning actually runs when async fails
  - Moved cleanup to finally blocks so KA9Q channels always get closed

  Should hopefully fix the issue where scanning would freeze after a while with concurrent workers enabled.