### PR TITLE
Fix problem with fsk_demod stats output on GCC14

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta16"
+__version__ = "1.8.2-beta17"
 
 # Global Variables
 

--- a/utils/fsk_demod.c
+++ b/utils/fsk_demod.c
@@ -363,10 +363,9 @@ int main(int argc,char *argv[]){
                 /* Print standard 2FSK stats */
 
                 fprintf(stderr,"{");
-                time_t seconds  = time(NULL);
 
                 // Cast some values to avoid problems if time is long long
-                fprintf(stderr,"\"secs\": %lld, \"samples\": %lld, \"EbNodB\": %5.1f, \"ppm\": %4d,",(long long)seconds, (long long)sample_count, stats.snr_est, (int)fsk->ppm);                float *f_est;
+                fprintf(stderr,"\"samples\": %ld, \"EbNodB\": %5.1f, \"ppm\": %4d,", sample_count, stats.snr_est, (int)fsk->ppm);                float *f_est;
                 if (fsk->freq_est_type)
                     f_est = fsk->f2_est;
                 else


### PR DESCRIPTION
In GCC14 time_t is now 64-bit by default. The print statement for the stats output made the assumption it was a long. This broke things in interesting ways, including resulting in SNR values that were nonsensical.

The seconds output was never used by anything, so I've just removed it.