### PR TITLE
v1.8.2-beta18 - Fixes to log file reading and writing

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.8.2-beta17"
+__version__ = "1.8.2-beta18"
 
 # Global Variables
 

--- a/auto_rx/autorx/log_files.py
+++ b/auto_rx/autorx/log_files.py
@@ -299,9 +299,26 @@ def read_log_file(filename, skewt_decimation=10):
         )
 
     else:
-        # Grab everything
-        #_data = np.genfromtxt(_file, dtype=None, encoding="ascii", delimiter=",")
-        _data = np.genfromtxt(_file, dtype=None, delimiter=",")
+        # Newer fields
+        # timestamp,serial,frame,lat,lon,alt,vel_v,vel_h,heading,temp,humidity,pressure,type,freq_mhz,snr,f_error_hz,sats,batt_v,burst_timer,aux_data
+
+        # There is a behaviour change between numpy <2.3 and >=2.3 (tested between 1.26.4 and 2.3.4)
+        # Numpy will no longer allow 'upgrading' a dtype from np.integer to a string type during type inference.
+        # This was deprecated in v2.3.0 - https://numpy.org/devdocs/release/2.3.0-notes.html#expired-deprecations
+        # "Converting np.complex, np.integer, np.signedinteger, np.unsignedinteger, np.generic to a dtype errors (deprecated since 1.19)"
+
+        # A common example of this is the burst-timer field, which is set to -1 if there is no burst timer data,
+        # but then gets set to a time (HH:MM:SS) when there is burst timer data.
+
+        # The workaround now is to ignore the burst_timer and aux_data fields, and look at a better way of representing missing data in log files in the future. 
+
+        _data = np.genfromtxt(
+            _file, 
+            dtype=None, 
+            encoding="ascii", 
+            delimiter=",", 
+            usecols=(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17))
+
 
     _file.close()
 

--- a/auto_rx/autorx/logger.py
+++ b/auto_rx/autorx/logger.py
@@ -178,15 +178,15 @@ class TelemetryLogger(object):
                     "%H:%M:%S", time.gmtime(telemetry["bt"])
                 )
             else:
-                _log_line += ",-1"
+                _log_line += ","
         else:
-            _log_line += ",-1"
+            _log_line += ","
 
         # Add Aux data, if it exists.
         if "aux" in telemetry:
             _log_line += ",%s" % telemetry["aux"].strip()
         else:
-            _log_line += ",-1"
+            _log_line += ","
 
         # Terminate the log line.
         _log_line += "\n"


### PR DESCRIPTION

<img width="800" height="521" alt="image" src="https://github.com/user-attachments/assets/22515918-173b-4983-8af8-04b60b2da51f" />


`burst_timer` and `aux` fields in log files were written out as -1 if no data existed.

In Numpy v2.3.0, genfromtxt will no longer 'upgrade' a dtype from something like np.integer to a string. This means that when reading in a log file with genfromtxt, if the type of a column changes from an integer to a string mid-file, it barfs with the error:
`TypeError: Converting 'np.integer' or 'np.signedinteger' to a dtype is not allowed`

As a result, reading of log files breaks. Somehow I also ended up making another change which broke things even more: https://github.com/projecthorus/radiosonde_auto_rx/commit/2293581885e23ee7d52ba3b4929d8ff033274834#diff-8aa819bbfc9d4b6b704c96696908490aac3ff32620abc7103bee9589ee446526R303
This resulted more and different errors due to the type of the 'string' fields being bytes. 
Dunno what I was thinking here.

So, the changes I'm making:
- When reading in log files, we now don't read in the burst_timer and aux columns at all. We weren't using them anyway.
- When writing log files, we don't use -1 as a 'no data' indicator for these fields, instead we just use an empty entry (e.g. `,,`)

Some basic testing (loading some known-broken log files in the historical page) done with numpy versions 1.24 and 2.3, and it seems OK...