### PR TITLE
Only scan sonde types feature

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -159,6 +159,7 @@ def start_scanner():
             only_scan=config["only_scan"],
             always_scan=config["always_scan"],
             never_scan=config["never_scan"],
+            only_scan_sonde_types=config.get("only_scan_sonde_types", []),
             snr_threshold=config["snr_threshold"],
             min_distance=config["min_distance"],
             quantization=config["quantization"],

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -80,6 +80,7 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         "only_scan": [],
         "never_scan": [],
         "always_scan": [],
+        "only_scan_sonde_types": [],
         "always_decode": [],
         # Location Settings
         "station_lat": 0.0,
@@ -275,6 +276,18 @@ def read_auto_rx_config(filename, no_sdr_test=False):
             )
             auto_rx_config["always_scan"] = json.loads(
                 config.get("search_params", "greylist")
+            )
+
+        # only_scan_sonde_types: optional allowlist of sonde types passed to
+        # dft_detect via --types. Empty list (or missing key) means scan all.
+        # User-facing names ("DFM", "RS41", ...) get translated to internal
+        # rs_hdr type names in scan.py / scan_async.py before invocation.
+        if (
+            config.has_option("search_params", "only_scan_sonde_types")
+            and config.get("search_params", "only_scan_sonde_types") != ""
+        ):
+            auto_rx_config["only_scan_sonde_types"] = json.loads(
+                config.get("search_params", "only_scan_sonde_types")
             )
 
         # Location Settings

--- a/auto_rx/autorx/scan.py
+++ b/auto_rx/autorx/scan.py
@@ -224,6 +224,63 @@ def read_rtl_power(filename):
     return (freq, power, freq_step)
 
 
+# User-facing sonde type names → dft_detect rs_hdr type names.
+# Several user-facing names map to the same internal entry (e.g. "M10" and "M20"
+# share a single rs_hdr slot that classifies at runtime). "IMET", "IMET1", and
+# "IMET4" all require IMETafsk's detection to fire; the post-classification
+# inside dft_detect redirects to the right output type, so enabling IMETafsk
+# is sufficient.
+SONDE_TYPE_MAP = {
+    "RS41":     ["RS41"],
+    "RS92":     ["RS92"],
+    "DFM":      ["DFM9"],
+    "M10":      ["M10"],
+    "M20":      ["M10"],
+    "IMET":     ["IMETafsk"],
+    "IMET1":    ["IMETafsk"],
+    "IMET4":    ["IMETafsk"],
+    "IMET5":    ["IMET5"],
+    "LMS6":     ["LMS6"],
+    "MK2LMS":   ["MK2LMS"],
+    "MEISEI":   ["MEISEI"],
+    "MRZ":      ["MRZ"],
+    "C34C50":   ["C34C50"],
+    "RD94RD41": ["RD94RD41"],
+}
+
+
+def build_dft_detect_types_arg(only_scan_sonde_types):
+    """Translate a user-facing sonde type allowlist into the comma-separated
+    string passed to dft_detect's --types flag.
+
+    Returns "" if the input list is empty or None (caller should then omit
+    the --types flag entirely so dft_detect scans all types).
+    Unknown user-facing names log a warning and are skipped.
+    """
+    if not only_scan_sonde_types:
+        return ""
+    internal = []
+    seen = set()
+    for name in only_scan_sonde_types:
+        key = str(name).strip().upper()
+        # Match map keys case-insensitively.
+        mapped = None
+        for k, v in SONDE_TYPE_MAP.items():
+            if k.upper() == key:
+                mapped = v
+                break
+        if mapped is None:
+            logging.warning(
+                "Scanner - only_scan_sonde_types: unknown sonde type '%s' (ignored)" % name
+            )
+            continue
+        for t in mapped:
+            if t not in seen:
+                seen.add(t)
+                internal.append(t)
+    return ",".join(internal)
+
+
 def parse_dft_detect_output(ret_output, sdr_name):
     """
     Parse dft_detect output and return detected sonde type and offset.
@@ -425,7 +482,8 @@ def detect_sonde(
     bias=False,
     save_detection_audio=False,
     ngp_tweak=False,
-    wideband_sondes=False
+    wideband_sondes=False,
+    only_scan_sonde_types=None
 ):
     """Receive some FM and attempt to detect the presence of a radiosonde.
 
@@ -596,8 +654,10 @@ def detect_sonde(
 
         # Sample decoding / detection
         # Note that we detect for dwell_time seconds, and timeout after dwell_time*2, to catch if no samples are being passed through.
+        _types_arg = build_dft_detect_types_arg(only_scan_sonde_types)
+        _types_flag = (" --types %s" % _types_arg) if _types_arg else ""
         rx_test_command += (
-            os.path.join(rs_path, "dft_detect") + " -t %d 2>/dev/null" % dwell_time
+            os.path.join(rs_path, "dft_detect") + " -t %d%s 2>/dev/null" % (dwell_time, _types_flag)
         )
 
     _sdr_name = get_sdr_name(
@@ -677,6 +737,7 @@ class SondeScanner(object):
         only_scan=[],
         always_scan=[],
         never_scan=[],
+        only_scan_sonde_types=None,
         snr_threshold=10,
         min_distance=1000,
         quantization=10000,
@@ -769,6 +830,7 @@ class SondeScanner(object):
         self.only_scan = only_scan
         self.always_scan = always_scan
         self.never_scan = never_scan
+        self.only_scan_sonde_types = only_scan_sonde_types
         self.snr_threshold = snr_threshold
         self.min_distance = min_distance
         self.quantization = quantization
@@ -1178,7 +1240,8 @@ class SondeScanner(object):
                     gain=self.gain,
                     bias=self.bias,
                     save_detection_audio=self.save_detection_audio,
-                    wideband_sondes=self.wideband_sondes
+                    wideband_sondes=self.wideband_sondes,
+                    only_scan_sonde_types=self.only_scan_sonde_types
                 )
 
                 # Process results
@@ -1224,7 +1287,8 @@ class SondeScanner(object):
                     bias=self.bias,
                     dwell_time=self.detect_dwell_time,
                     save_detection_audio=self.save_detection_audio,
-                    wideband_sondes=self.wideband_sondes
+                    wideband_sondes=self.wideband_sondes,
+                    only_scan_sonde_types=self.only_scan_sonde_types
                 )
 
                 if detected != None:

--- a/auto_rx/autorx/scan_async.py
+++ b/auto_rx/autorx/scan_async.py
@@ -53,6 +53,7 @@ async def detect_sonde_async(
     save_detection_audio: bool = False,
     ngp_tweak: bool = False,
     wideband_sondes: bool = False,
+    only_scan_sonde_types: Optional[list] = None,
 ) -> Tuple[Optional[str], float]:
     """
     Async version of detect_sonde that uses asyncio subprocess for non-blocking execution.
@@ -102,6 +103,12 @@ async def detect_sonde_async(
     except RuntimeError:
         loop = asyncio.get_event_loop()  # Fallback
 
+    # Build --types flag once for both _mode branches. Empty list / None means
+    # omit the flag entirely so dft_detect scans all types (existing behavior).
+    from .scan import build_dft_detect_types_arg
+    _types_arg = build_dft_detect_types_arg(only_scan_sonde_types)
+    _types_flag = (" --types %s" % _types_arg) if _types_arg else ""
+
     if _mode == "IQ":
         # IQ decoding
         # Note: We rely on asyncio.wait_for for timeout, not external timeout_cmd
@@ -143,8 +150,8 @@ async def detect_sonde_async(
         dft_detect_path = os.path.join(rs_path, "dft_detect")
         rx_test_command += (
             shlex.quote(dft_detect_path)
-            + " -t %d --iq --bw %d --dc - %d 16 2>/dev/null"
-            % (dwell_time, _if_bw, _iq_bw)
+            + " -t %d --iq --bw %d --dc%s - %d 16 2>/dev/null"
+            % (dwell_time, _if_bw, _types_flag, _iq_bw)
         )
 
     elif _mode == "FM":
@@ -184,7 +191,7 @@ async def detect_sonde_async(
 
         dft_detect_path = os.path.join(rs_path, "dft_detect")
         rx_test_command += (
-            shlex.quote(dft_detect_path) + " -t %d 2>/dev/null" % dwell_time
+            shlex.quote(dft_detect_path) + " -t %d%s 2>/dev/null" % (dwell_time, _types_flag)
         )
 
     _sdr_name = get_sdr_name(

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -129,6 +129,14 @@ never_scan = []
 # This is useful when you know the regular frequency of a local sonde, but still want to allow detections on other frequencies.
 always_scan = []
 
+# only_scan_sonde_types - Restrict the dft_detect scanner to only test for these sonde types.
+# Each scan cycle currently tests the signal against ~14 sonde-type templates; if your region
+# only ever sees a couple of types you can save CPU by listing just those. Empty list (default)
+# means scan for every supported type. Names are case-insensitive.
+# Valid names: RS41, RS92, DFM, M10, M20, IMET, IMET5, LMS6, MK2LMS, MEISEI, MRZ, C34C50, RD94RD41
+# Example for a DFM-and-RS41-only region: only_scan_sonde_types = ["DFM", "RS41"]
+only_scan_sonde_types = []
+
 # always_decode - Always-running decoders. Only possible in a multi-SDR (or network-based SDR) system.
 # List must be in the form: [[401.5,"RS41"], [402.5,"DFM"], [400.5,"M10"], [400.5,"IMET"]]
 # Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMETWIDE, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -131,6 +131,14 @@ never_scan = []
 # This is useful when you know the regular frequency of a local sonde, but still want to allow detections on other frequencies.
 always_scan = []
 
+# only_scan_sonde_types - Restrict the dft_detect scanner to only test for these sonde types.
+# Each scan cycle currently tests the signal against ~14 sonde-type templates; if your region
+# only ever sees a couple of types you can save CPU by listing just those. Empty list (default)
+# means scan for every supported type. Names are case-insensitive.
+# Valid names: RS41, RS92, DFM, M10, M20, IMET, IMET5, LMS6, MK2LMS, MEISEI, MRZ, C34C50, RD94RD41
+# Example for a DFM-and-RS41-only region: only_scan_sonde_types = ["DFM", "RS41"]
+only_scan_sonde_types = []
+
 # always_decode - Always-running decoders. Only possible in a multi-SDR (or network-based SDR) system.
 # List must be in the form: [[401.5,"RS41"], [402.5,"DFM"], [400.5,"M10"], [400.5,"IMET"]]
 # Valid sonde types: RS41, RS92, DFM, M10, M20, IMET, IMETWIDE, IMET5, MK2LMS, LMS6, MEISEI, MRZ, MTS01


### PR DESCRIPTION
## BLOCKED BY: https://github.com/rs1729/RS/pull/61

Adds a new `station.cfg` option that lets us restrict which sonde types `dft_detect` actually scans for.

Right now every scan cycle runs the signal through ~14 type templates (DFM, RS41, RS92, LMS6, IMET5, MK2LMS, M10/M20, MEISEI, RD94RD41, MRZ, MTS01, WXR301, WXRPN9, IMETafsk) before deciding nothing's there. If you live somewhere that only ever sees one or two of those, the other dozen correlations are CPU work for nothing.

```ini
# Empty list (default) = scan all types, same as today.
only_scan_sonde_types = ["DFM", "RS41"]
```

User-facing names get mapped to the internal `rs_hdr` names inside `scan.py` (e.g. "DFM" → "DFM9", "IMET"/"IMET1"/"IMET4" all enable IMETafsk's detection path, M10 and M20 share one entry). `dft_detect` gets a new `--types` CLI flag that takes the comma-separated list of internal names.

I tested it on a `/dev/zero` input — full scan vs DFM9+RS41 only is about 4x faster on my machine. Real-world will be less dramatic since decode time isn't affected, but for stations stuck in scan mode most of the time it's a real win.

`dft_detect` gets a new `--types` flag with case-insensitive matching, whitespace tolerance, and a warning if you ask for a type that was excluded at compile time (NOC34C50/NOIMET1AB). Config plumbing goes through `config.py`, `scan.py`, `scan_async.py`, and `auto_rx.py`, and both `station.cfg.example` files have docs. Default behavior with no flag passed is identical to before.