### PR TITLE
Use FFTW if available

### DIFF
--- a/scan/Makefile
+++ b/scan/Makefile
@@ -1,5 +1,22 @@
-CFLAGS = -O3 -w -Wno-unused-variable -DNOC34C50 -DNOIMET1AB
-LDLIBS = -lm
+# Auto-detect single-precision FFTW3 (fftw3f). When available, dft_detect is
+# built with FFTW backing its core FFT for a meaningful speedup in the
+# correlation inner loop. When not available, the build falls back to the
+# in-tree naive radix-2 FFT and behavior is unchanged. No install-doc
+# changes are required: users who already have libfftw3-dev installed (e.g.
+# the Docker build, anyone with KA9Q-radio) automatically get the faster
+# path, and everyone else builds as before.
+HAVE_FFTW3F := $(shell pkg-config --exists fftw3f 2>/dev/null && echo 1)
+
+ifeq ($(HAVE_FFTW3F),1)
+    FFTW_CFLAGS := -DHAVE_FFTW3 $(shell pkg-config --cflags fftw3f)
+    FFTW_LDLIBS := $(shell pkg-config --libs fftw3f)
+else
+    FFTW_CFLAGS :=
+    FFTW_LDLIBS :=
+endif
+
+CFLAGS = -O3 -w -Wno-unused-variable -DNOC34C50 -DNOIMET1AB $(FFTW_CFLAGS)
+LDLIBS = -lm $(FFTW_LDLIBS)
 
 PROGRAMS := dft_detect
 


### PR DESCRIPTION
## Supported by https://github.com/rs1729/RS/pull/60

Companion to https://github.com/rs1729/RS/pull/60 which adds an optional FFTW backend to `dft_detect`. This just teaches our Makefile to auto-detect `libfftw3-dev` via pkg-config and pass `-DHAVE_FFTW3 -lfftw3f` when it's there. Without the lib, build behavior is unchanged.

Don't merge until the rs1729 PR lands and `dft_detect.c` is re-vendored — until then the define is a no-op (just adds a useless link to libfftw3f if it happens to be installed). Once it lands, dft_detect's forward DFT goes through FFTW for roughly a 4x faster correlation, which mostly shows up as lower CPU per scan rather than faster scans (we're sample-rate-bounded anyway).