### PR TITLE
Reuse HTTP sessions for SondeHub uploads

### DIFF
--- a/auto_rx/autorx/sondehub.py
+++ b/auto_rx/autorx/sondehub.py
@@ -76,6 +76,9 @@ class SondehubUploader(object):
         # Input Queue.
         self.input_queue = Queue()
 
+        # Reuse HTTP connections to SondeHub when the server keeps them open.
+        self.http_session = requests.Session()
+
         # Record of when we last uploaded a user station position to Sondehub.
         self.last_user_position_upload = 0
 
@@ -396,6 +399,7 @@ class SondehubUploader(object):
                 if self.input_processing_running == False:
                     break
 
+        self.http_session.close()
         self.log_info("Stopped Sondehub Uploader Thread.")
 
     def upload_telemetry(self, telem_list):
@@ -439,7 +443,7 @@ class SondehubUploader(object):
                     "Content-Type": "application/json",
                     "Date": formatdate(timeval=None, localtime=False, usegmt=True),
                 }
-                _req = requests.put(
+                _req = self.http_session.put(
                     self.SONDEHUB_URL,
                     _compressed_payload,
                     # TODO: Revisit this second timeout value.
@@ -448,7 +452,8 @@ class SondehubUploader(object):
                 )
             except Exception as e:
                 self.log_error("Upload Failed: %s" % str(e))
-                return
+                _retries += 1
+                continue
 
             if _req.status_code == 200:
                 # 200 is the only status code that we accept.
@@ -460,7 +465,7 @@ class SondehubUploader(object):
                 _upload_success = True
                 break
 
-            elif _req.status_code == 500:
+            elif _req.status_code in (500, 502, 503, 504):
                 # Server Error, Retry.
                 _retries += 1
                 continue
@@ -538,7 +543,7 @@ class SondehubUploader(object):
                     "Content-Type": "application/json",
                     "Date": formatdate(timeval=None, localtime=False, usegmt=True),
                 }
-                _req = requests.put(
+                _req = self.http_session.put(
                     self.SONDEHUB_STATION_POSITION_URL,
                     json=_position,
                     # TODO: Revisit this second timeout value.
@@ -547,7 +552,8 @@ class SondehubUploader(object):
                 )
             except Exception as e:
                 self.log_error("Upload Failed: %s" % str(e))
-                return
+                _retries += 1
+                continue
 
             if _req.status_code == 200:
                 # 200 is the only status code that we accept.
@@ -556,7 +562,7 @@ class SondehubUploader(object):
                 _upload_success = True
                 break
 
-            elif _req.status_code == 500:
+            elif _req.status_code in (500, 502, 503, 504):
                 # Server Error, Retry.
                 _retries += 1
                 continue


### PR DESCRIPTION
I'm getting ready to put a remote receiver on a mountain with a 4G connection to the Internet. Because data is expensive, I'm reviewing auto_rx's usage and discovered that it sets up and tears down a new HTTPS (TLS) connection every 15 seconds. This is both expensive and easy to fix.

This PR changes auto_rx to use HTTP sessions via `requests.Session` for SondeHub telemetry and listener uploads. This lets urllib3 reuse an existing HTTP connection when the server keeps it alive, avoiding repeated TCP and TLS setup for every upload batch.

This PR also fixes a pre-existing data-loss bug where transport exceptions bypassed `upload_retries` and dropped the telemetry batch immediately, including connection resets, stale keep-alive sockets, DNS failures, TCP connect failures, and read timeouts. This matters more once connections are pooled, since transport exceptions can indicate the harmless situation that an idle connection has been dropped, so this PR fixes the retry behavior at the same time.

Tested with a live sonde and real SondeHub uploads to verify uploads still work. Measured impact using tcpdump at 15 second SondeHub upload intervals; the table shows per-upload savings:

|  | TX/upload | RX/upload | Total/upload | Packets out/in |
| --- | ---: | ---: | ---: | ---: |
| Before | 4,026 B | 7,142 B | 11,168 B | 16 / 13 |
| After | 1,407 B | 583 B | 1,990 B | 3 / 2 |
| Savings | -65% | -92% | -82% | |

At one upload every 15 seconds, a 90 minute receive window is about 360 uploads, so this saves roughly 9,178 B * 360 = 3.3 MB per flight.

The main reduction is avoiding retransmission of the TLS certificate chain on every upload. It also reduces the number of RTTs because we avoid repeated TCP connection setup/teardown and TLS handshakes.

NOTE: If this PR looks too invasive, I can submit a simpler one that simply uses HTTP sessions (it's 3 lines) and does not also fix the retry logic.
