### PR TITLE
v1.9.0-beta10 - ka9q-radio updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,13 +59,18 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
   cd /root/spyserver_client && \
   make
 
-# Compile ka9q-radio from source
-RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
-  cd /root/ka9q-radio && \
-  git checkout e0b5ee818ce87f7041d80f6838dca1c8f140cf97 && cd src && \
-  make \
-    ARCHOPTS= \
-    tune powers pcmrecord
+# Compile ka9q-radio from source on 64-bit architectures.
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+    amd64|arm64) \
+      git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
+      cd /root/ka9q-radio && \
+      git checkout e1224dcd1991637ba8e1caa68cd802e1b22933de && \
+      cd src && \
+      make ARCHOPTS= tune powers pcmrecord && \
+      install -m 0755 tune powers pcmrecord /root/target/usr/local/bin/ \
+      ;; \
+  esac
 
 # Copy in radiosonde_auto_rx.
 COPY . /root/radiosonde_auto_rx
@@ -100,7 +105,7 @@ RUN apt-get update && \
   usbutils && \
   rm -rf /var/lib/apt/lists/*
 
-# Copy rtl-sdr from the build container.
+# Copy locally compiled utilities from the build container.
 COPY --from=build /root/target /
 RUN ldconfig
 
@@ -115,11 +120,6 @@ COPY --from=build /root/radiosonde_auto_rx/auto_rx/ /opt/auto_rx/
 COPY --from=build /root/spyserver_client/ss_client /opt/auto_rx/
 RUN ln -s ss_client /opt/auto_rx/ss_iq && \
   ln -s ss_client /opt/auto_rx/ss_power
-
-# Copy ka9q-radio utilities 
-COPY --from=build /root/ka9q-radio/src/tune /usr/local/bin/
-COPY --from=build /root/ka9q-radio/src/powers /usr/local/bin/
-COPY --from=build /root/ka9q-radio/src/pcmrecord /usr/local/bin/
 
 # Allow mDNS resolution for ka9q-radio utilities
 RUN sed -i -e 's/files dns/files mdns4_minimal [NOTFOUND=return] dns/g' /etc/nsswitch.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,7 +62,7 @@ RUN git clone https://github.com/miweber67/spyserver_client.git /root/spyserver_
 # Compile ka9q-radio from source
 RUN git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
   cd /root/ka9q-radio && \
-  git checkout e1224dcd1991637ba8e1caa68cd802e1b22933de && cd src && \
+  git checkout e0b5ee818ce87f7041d80f6838dca1c8f140cf97 && cd src && \
   make \
     ARCHOPTS= \
     tune powers pcmrecord

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN case "$TARGETARCH" in \
     amd64|arm64) \
       git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
       cd /root/ka9q-radio && \
-      git checkout e1224dcd1991637ba8e1caa68cd802e1b22933de && \
+      git checkout 802174e9adb241bd311d7006925cbed92cd2abc1 && \
       cd src && \
       make ARCHOPTS= tune powers pcmrecord && \
       install -m 0755 tune powers pcmrecord /root/target/usr/local/bin/ \

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.9.0-beta9"
+__version__ = "1.9.0-beta10"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -860,7 +860,7 @@ class SondeDecoder(object):
                 decode_cmd += f" tee {self.save_decode_iq_path} |"
 
             # CF-06 Decoder, in IQ input mode
-            decode_cmd += f"./cf06ht03mod --json --IQ 0.0 --lpbw 12 --dc  - {_sample_rate} 16 2>/dev/null"
+            decode_cmd += f"./cf06ht03mod --json {self.raw_file_option} --IQ 0.0 --lpbw 12 --dc  - {_sample_rate} 16 2>/dev/null"
 
 
         elif self.sonde_type == "SRSC50":

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -18,12 +18,17 @@ def ka9q_setup_channel(
     frequency,
     sample_rate,
     scan,
-    channel_filter = None
+    channel_filter = None,
+    startup_timeout = 10
 ):
     if scan:
-        ssrc="04"
+        ssrc = "04"
+        # For scan channels, set the lifetime to 60 seconds (50 Hz * 60)
+        # To ensure they get closed out even if the close call fails
+        lifetime = "--lifetime 3000"
     else:
-        ssrc="01"
+        ssrc = "01"
+        lifetime = ""
 
     # tune --samprate 48000 --frequency 404m09 --mode iq --ssrc 404090000 --radio sonde.local
 
@@ -35,7 +40,7 @@ def ka9q_setup_channel(
         _high = int(int(sample_rate) / 2.4)
 
     _cmd = (
-        f"{timeout_cmd()} 5 " # Add a timeout, because connections to non-existing servers block for ages
+        f"{timeout_cmd()} {startup_timeout} " # Add a timeout, because connections to non-existing servers block for ages
         f"tune "
         f"--samprate {int(sample_rate)} "
         f"--mode iq "
@@ -43,6 +48,7 @@ def ka9q_setup_channel(
         f"--frequency {int(frequency)} "
         f"--ssrc {round(frequency / 1000)}{ssrc} "
         f"--radio {sdr_hostname}"
+        f"{lifetime}"
     )
 
     logging.debug(f"KA9Q - Starting channel at {frequency} Hz, with command: {_cmd}")
@@ -62,7 +68,7 @@ def ka9q_setup_channel(
 
         if e.returncode == 124:
             logging.critical(
-                f"KA9Q ({sdr_hostname}) - tune call failed while opening channel with a timeout. Is the server running?"
+                f"KA9Q ({sdr_hostname}) - tune call failed while opening channel (ssrc {round(frequency / 1000)}{ssrc}) with a timeout. Is the server running?"
             )
         elif e.returncode == 127:
             logging.critical(
@@ -70,7 +76,7 @@ def ka9q_setup_channel(
             )
         else:
             logging.critical(
-                f"KA9Q ({sdr_hostname}) - tune call failed while opening channel with return code {e.returncode}."
+                f"KA9Q ({sdr_hostname}) - tune call failed while opening channel (ssrc {round(frequency / 1000)}{ssrc}) with return code {e.returncode}."
             )
             # Look at the error output in a bit more details.
             #_output = e.output.decode("ascii")
@@ -84,7 +90,8 @@ def ka9q_setup_channel(
 def ka9q_close_channel(
     sdr_hostname,
     frequency,
-    scan
+    scan,
+    startup_timeout = 10
 ):
     if scan:
         ssrc="04"
@@ -92,7 +99,7 @@ def ka9q_close_channel(
         ssrc="01"
 
     _cmd = (
-        f"{timeout_cmd()} 5 " # Add a timeout, because connections to non-existing servers block for ages
+        f"{timeout_cmd()} {startup_timeout} " # Add a timeout, because connections to non-existing servers block for ages
         f"tune "
         f"--samprate 48000 "
         f"--mode iq "
@@ -119,7 +126,7 @@ def ka9q_close_channel(
 
         if e.returncode == 124:
             logging.critical(
-                f"KA9Q ({sdr_hostname}) - tune call failed while closing channel with a timeout. Is the server running?"
+                f"KA9Q ({sdr_hostname}) - tune call failed while closing channel (ssrc {round(frequency / 1000)}{ssrc} ) with a timeout. Is the server running?"
             )
         elif e.returncode == 127:
             logging.critical(
@@ -127,7 +134,7 @@ def ka9q_close_channel(
             )
         else:
             logging.critical(
-                f"KA9Q ({sdr_hostname}) - tune call failed while closing chanel with return code {e.returncode}."
+                f"KA9Q ({sdr_hostname}) - tune call failed while closing chanel (ssrc {round(frequency / 1000)}{ssrc} ) with return code {e.returncode}."
             )
             # Look at the error output in a bit more details.
             #_output = e.output.decode("ascii")

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -47,7 +47,7 @@ def ka9q_setup_channel(
         f"--low {_low} --high {_high} "
         f"--frequency {int(frequency)} "
         f"--ssrc {round(frequency / 1000)}{ssrc} "
-        f"--radio {sdr_hostname}"
+        f"--radio {sdr_hostname} "
         f"{lifetime}"
     )
 

--- a/auto_rx/autorx/ka9q.py
+++ b/auto_rx/autorx/ka9q.py
@@ -96,9 +96,10 @@ def ka9q_close_channel(
         f"tune "
         f"--samprate 48000 "
         f"--mode iq "
-        f"--frequency 0 "
+        f"--frequency {int(frequency)} "
         f"--ssrc {round(frequency / 1000)}{ssrc} "
-        f"--radio {sdr_hostname}"
+        f"--radio {sdr_hostname} "
+        f"--lifetime 50" # Use the lifetime argument to cause this channel to shutdown after 50 frames (1 second)
     )
 
     logging.debug(f"KA9Q - Closing channel at {frequency} Hz, with command: {_cmd}")

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -112,9 +112,10 @@ def test_sdr(
             f"{timeout_cmd()} {timeout} " # Add a timeout, because connections to non-existing servers block for ages
             f"tune "
             f"--samprate 48000 --mode iq "
-            f"--frequency 0 "
+            f"--frequency {int(check_freq)} "
             f"--ssrc {round(check_freq / 1000)}02 "
-            f"--radio {sdr_hostname}"
+            f"--radio {sdr_hostname} "
+            f"--lifetime 50"
         )
 
         logging.debug(f"KA9Q - Closing testing channel using command: {_cmd}")

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -532,7 +532,9 @@ def read_ka9q_power_log(log_filename, sdr_name):
     # ka9q powers log files are csv's, with the first 5 fields in each line describing the time and frequency scan parameters
     # for the remaining fields, which contain the power samples.
 
-    burn_line = True
+    #burn_line = True
+    # 1.9.0-beta10, using newer ka9q-radio where we just request one line
+    burn_line = False
 
     for line in f:
         if burn_line:
@@ -562,6 +564,9 @@ def read_ka9q_power_log(log_filename, sdr_name):
         # Add frequency range and samples to output buffers.
         freq = np.append(freq, freq_range)
         power = np.append(power, samples)
+
+        # Break after reading one line
+        break
 
     f.close()
 
@@ -788,9 +793,11 @@ def get_power_spectrum(
             f"-f {_center_freq} "
             f"-w {step} "
             f"-b {_bins} "
-            f"-i {integration_time} "
+            #f"-i {integration_time} "
             f"-s {_ssrc} "
-            f"-c 2 " # burn the first scan result due to no dwelling
+            #f"-c 1 " # burn the first scan result due to no dwelling
+            # Some hardcoded values for ka9q-radio to check behaviour
+            f"-a {step} -i 2 -c 1"
             f"> {_log_filename}"
         )
 

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -797,7 +797,7 @@ def get_power_spectrum(
             f"-s {_ssrc} "
             #f"-c 1 " # burn the first scan result due to no dwelling
             # Some hardcoded values for ka9q-radio to check behaviour
-            f"-a {step} -i 2 -c 1"
+            f"-a {step} -i 2 -c 1 "
             f"> {_log_filename}"
         )
 

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -77,7 +77,8 @@ def test_sdr(
             f"--samprate 48000 --mode iq "
             f"--frequency {int(check_freq)} "
             f"--ssrc {round(check_freq / 1000)}02 "
-            f"--radio {sdr_hostname}"
+            f"--radio {sdr_hostname} "
+            f"--lifetime 3000" # Ensure the channel closes out after 60 seconds max
         )
 
         logging.debug(f"KA9Q - Testing using command: {_cmd}")
@@ -91,7 +92,7 @@ def test_sdr(
 
             if e.returncode == 124:
                 logging.critical(
-                    f"KA9Q ({sdr_hostname}) - tune call failed with a timeout. Is the server running?"
+                    f"KA9Q ({sdr_hostname}) - tune call failed (ssrc {round(check_freq / 1000)}02 ) with a timeout. Is the server running?"
                 )
             elif e.returncode == 127:
                 logging.critical(
@@ -99,7 +100,7 @@ def test_sdr(
                 )
             else:
                 logging.critical(
-                    f"KA9Q ({sdr_hostname}) - tune call failed with return code {e.returncode}."
+                    f"KA9Q ({sdr_hostname}) - tune call faile (ssrc {round(check_freq / 1000)}02 ) with return code {e.returncode}."
                 )
                 # Look at the error output in a bit more details.
                 #_output = e.output.decode("ascii")


### PR DESCRIPTION
WARNING - This requires ka9q-radio minimum commit: `802174e9adb241bd311d7006925cbed92cd2abc1`

Main changes:
- Use new ka9q-radio version.
- Close out ka9q-radio channels by running tune with the --lifetime parameter set to 50 (1 second), so they are closed after that time
- Start up scan and test channels with a default lifetime of 60 seconds, to ensure they get closed.
- Use new powers averaging argument. I'm currently hardcoding all the powers arguments, with 1 second averaging, and one cycle. 

Also added raw packet saving option for CF6GTH decoder.