### PR TITLE
Update ka9q-radio commit, better averaging in powers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ RUN case "$TARGETARCH" in \
     amd64|arm64) \
       git clone https://github.com/ka9q/ka9q-radio.git /root/ka9q-radio && \
       cd /root/ka9q-radio && \
-      git checkout 4b472b2420ce60bb34ecc76e803fcb38dc45e81a && \
+      git checkout 1a53566666a9df59734b19806c5abd0e50476a40 && \
       cd src && \
       make ARCHOPTS= tune powers pcmrecord && \
       install -m 0755 tune powers pcmrecord /root/target/usr/local/bin/ \

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.9.0-beta10"
+__version__ = "1.9.0-beta11"
 
 # Global Variables
 

--- a/auto_rx/autorx/sdr_wrappers.py
+++ b/auto_rx/autorx/sdr_wrappers.py
@@ -532,14 +532,7 @@ def read_ka9q_power_log(log_filename, sdr_name):
     # ka9q powers log files are csv's, with the first 5 fields in each line describing the time and frequency scan parameters
     # for the remaining fields, which contain the power samples.
 
-    #burn_line = True
-    # 1.9.0-beta10, using newer ka9q-radio where we just request one line
-    burn_line = False
-
     for line in f:
-        if burn_line:
-            burn_line = False
-            continue
 
         # Split line into fields.
         fields = line.rstrip().split(",", 5)
@@ -793,11 +786,9 @@ def get_power_spectrum(
             f"-f {_center_freq} "
             f"-w {step} "
             f"-b {_bins} "
-            #f"-i {integration_time} "
             f"-s {_ssrc} "
-            #f"-c 1 " # burn the first scan result due to no dwelling
-            # Some hardcoded values for ka9q-radio to check behaviour
-            f"-a {step} -i 2 -c 1 "
+            # Average for the user-defined integration time.
+            f"-a {int(step*integration_time)} -c 1 "
             f"> {_log_filename}"
         )
 


### PR DESCRIPTION
ka9q-commit required is now: 1a53566666a9df59734b19806c5abd0e50476a40

The scan_dwell_time config setting now sets the averaging time. 