### PR TITLE
decoder min spacing to 7500 Hz, handle M10/M20 misdetections

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -35,7 +35,7 @@ if sys.version_info < (3, 6):
 
 import autorx
 from autorx.scan import SondeScanner
-from autorx.decode import SondeDecoder, VALID_SONDE_TYPES, DRIFTY_SONDE_TYPES
+from autorx.decode import SondeDecoder, VALID_SONDE_TYPES
 from autorx.logger import TelemetryLogger
 from autorx.email_notification import EmailNotification
 from autorx.aprs import APRSUploader
@@ -360,9 +360,12 @@ def handle_scan_results():
                         if _decoding_sonde_type.startswith("-"):
                             _decoding_sonde_type = _decoding_sonde_type[1:]
 
-                        # Only check the frequency spacing if we have a known 'drifty' sonde type, *and* the new sonde type is of the same type.
-                        if (_decoding_sonde_type in DRIFTY_SONDE_TYPES) and (
-                            _decoding_sonde_type == _check_type
+                        # Check if the adjacent sonde is the same type
+                        #.. or possible a M10/M20 misdetection
+                        if (
+                            (_decoding_sonde_type == _check_type) or 
+                            (_decoding_sonde_type == 'M20' and _check_type == 'M10') or
+                            (_decoding_sonde_type == 'M10' and _check_type == 'M20')
                         ):
                             if abs(_key - _freq) < config["decoder_spacing_limit"]:
                                 # At this point, we can be pretty sure that there is another decoder already decoding this particular sonde ID.

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.9.0-beta11"
+__version__ = "1.9.0-beta12"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -48,10 +48,6 @@ VALID_SONDE_TYPES = [
     "SRSC50"
 ]
 
-# Known 'Drifty' Radiosonde types
-# NOTE: Due to observed adjacent channel detections of RS41s, the adjacent channel decoder restriction
-# is now applied to all radiosonde types. This may need to be re-evaluated in the future.
-DRIFTY_SONDE_TYPES = VALID_SONDE_TYPES  # ['RS92', 'DFM', 'LMS6']
 
 
 class SondeDecoder(object):

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -551,7 +551,8 @@ quantization = 10000
 # Decoder Spacing Limit - Only start a new decoder if it is separated from an existing decoder by at least
 # this value (Hz). This helps avoid issues where a drifting radiosonde is detected on two adjacent channels.
 # For Network SDR systems, we set this to a lower value than the usual default of 15 kHz, as we have better channel filtering.
-decoder_spacing_limit = 5000
+# 2026-07 Update - Increased this from 5000 to 7500 Hz due to issues with dual M20 decoders starting up on the same sonde.
+decoder_spacing_limit = 7500
 # Temporary Block Time (minutes) - How long to block encrypted or otherwise non-decodable sondes for.
 temporary_block_time = 120
 # Maximum Async Scan Workers - How many concurrent peak detection tasks to run during scanning.


### PR DESCRIPTION
New recommended [decoder_spacing_limit](https://github.com/projecthorus/radiosonde_auto_rx/blob/master/auto_rx/station.cfg.example.network#L553) is now 7500 Hz, to avoid dual decoders starting up on M20 radiosondes. 