### PR TITLE
1.9.0-beta14 - An attempt at avoiding adjacent decoders starting up

### DIFF
--- a/auto_rx/auto_rx.py
+++ b/auto_rx/auto_rx.py
@@ -441,7 +441,7 @@ def clean_task_list():
         if _running == False:
             # This task has stopped.
             # Check the exit state of the task for any abnormalities:
-            if (_exit_state == "Encrypted") or (_exit_state == "TempBlock"):
+            if (_exit_state == "Encrypted") or (_exit_state == "TempBlock") or (_exit_state == "Duplicate"):
                 # This task was a decoder, and it has encountered an encrypted sonde, or one too far away.
                 logging.info(
                     "Task Manager - Adding temporary block for frequency %.3f MHz"

--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.9.0-beta13"
+__version__ = "1.9.0-beta14"
 
 # Global Variables
 

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -1955,8 +1955,12 @@ class SondeDecoder(object):
                         continue
 
                     # Extract the currently decoded sonde type and start time from the currently running decoder.
-                    _decoder_id = autorx.task_list[_key]["task"].current_id
-                    _decoder_start_time = autorx.task_list[_key]["task"].decoder_start_time
+                    # Wrap this in a try/except as the task list might get modified while we are reading it.
+                    try:
+                        _decoder_id = autorx.task_list[_key]["task"].current_id
+                        _decoder_start_time = autorx.task_list[_key]["task"].decoder_start_time
+                    except:
+                        continue
 
                     if (self.current_id == _decoder_id) and (_decoder_start_time < self.decoder_start_time):
                         # Already another decoder decoding this sonde!

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -200,6 +200,9 @@ class SondeDecoder(object):
         """
         # Thread running flag
         self.decoder_running = True
+        # Flags that might eventually get checked from other threads, to avoid duplicate decoders running.
+        self.current_id = None
+        self.decoder_start_time = time.time()
 
         # Local copy of init arguments
         self.sonde_type = sonde_type
@@ -1918,6 +1921,9 @@ class SondeDecoder(object):
                 )
                 _telemetry["aprsid"] = None
 
+            # Update our 'currently decoding' ID
+            self.current_id = _telemetry['id']
+
             # If we have been provided a telemetry filter function, pass the telemetry data
             # through the filter, and return the response
             # By default, we will assume the telemetry is OK.
@@ -1938,6 +1944,28 @@ class SondeDecoder(object):
                 self.exit_state = "TempBlock"
                 self.decoder_running = False
                 return False
+
+            # Check for other decoders already decoding this sonde.
+            for _key in autorx.task_list.keys():
+                # Iterate through the task list, and only attempt to compare with those that are a decoder task.
+                # This is indicated by the task key being an integer (the sonde frequency).
+                if (type(_key) == int) or (type(_key) == float):
+                    # Skip this Decoder!
+                    if self.sonde_freq == _key:
+                        continue
+
+                    # Extract the currently decoded sonde type and start time from the currently running decoder.
+                    _decoder_id = autorx.task_list[_key]["task"].current_id
+                    _decoder_start_time = autorx.task_list[_key]["task"].decoder_start_time
+
+                    if (self.current_id == _decoder_id) and (_decoder_start_time < self.decoder_start_time):
+                        # Already another decoder decoding this sonde!
+                        self.log_error(
+                            f"This sonde already being decoded on {_key/1e6} MHz! Closing decoder."
+                        )
+                        self.exit_state = "Duplicate"
+                        self.decoder_running = False
+                        return False
 
             # Run telemetry from DFM sondes through real-time filter
             if self.enable_realtime_filter and (_telemetry["type"].startswith("DFM")):

--- a/auto_rx/autorx/decode.py
+++ b/auto_rx/autorx/decode.py
@@ -1964,7 +1964,7 @@ class SondeDecoder(object):
 
                     if (self.current_id == _decoder_id) and (_decoder_start_time < self.decoder_start_time):
                         # Already another decoder decoding this sonde!
-                        self.log_error(
+                        self.log_info(
                             f"This sonde already being decoded on {_key/1e6} MHz! Closing decoder."
                         )
                         self.exit_state = "Duplicate"


### PR DESCRIPTION
- Scanning/Decoding: Added a possible approach for avoiding adjacent decoders starting up. Decoders will now compare current serial numbers (internally called 'id') against other running decoders. If another older decoder is already decoding the same serial, the current decoder will now exit, and the frequency will be locked out for `temporary_block_time` minutes.