### PR TITLE
v1.9.0-beta16 - Carto API key and APRS fixes

### DIFF
--- a/auto_rx/autorx/__init__.py
+++ b/auto_rx/autorx/__init__.py
@@ -12,7 +12,7 @@ from queue import Queue
 # MINOR - New sonde type support, other fairly big changes that may result in telemetry or config file incompatability issus.
 # PATCH - Small changes, or minor feature additions.
 
-__version__ = "1.9.0-beta15"
+__version__ = "1.9.0-beta16"
 
 # Global Variables
 

--- a/auto_rx/autorx/aprs.py
+++ b/auto_rx/autorx/aprs.py
@@ -125,7 +125,7 @@ def telemetry_to_aprs_position(
     _aprs_timestamp = sonde_data["datetime_dt"].strftime("%H%M%S")
 
     # Generate course/speed data, if provided in the telemetry dictionary
-    if ("heading" in sonde_data.keys()) and ("vel_h" in sonde_data.keys()):
+    if (("heading" in sonde_data.keys()) and (sonde_data["heading"]>-1)) and (("vel_h" in sonde_data.keys()) and (sonde_data["vel_h"]>-1)):
         course_speed = "%03d/%03d" % (
             int(sonde_data["heading"]),
             int(sonde_data["vel_h"] * 1.944),

--- a/auto_rx/autorx/config.py
+++ b/auto_rx/autorx/config.py
@@ -174,7 +174,8 @@ def read_auto_rx_config(filename, no_sdr_test=False):
         # "sondehub_contact_email": "none@none.com" # Commented out to ensure a warning message is shown on startup
         "wideband_sondes": False, # Wideband sonde detection / decoding
         "close_on_encrypted": True,
-        "exclude_types": ["IMET1AB","C34C50"] # Sonde types to exclude from detections
+        "exclude_types": ["IMET1AB","C34C50"], # Sonde types to exclude from detections
+        "carto_api_key": ""
     }
 
     try:
@@ -833,6 +834,16 @@ def read_auto_rx_config(filename, no_sdr_test=False):
                 "Config - No or invalid exclude_types settings, defaulting to [\"IMET1AB\",\"C34C50\"]"
             )
             auto_rx_config["exclude_types"] = ['IMET1AB','C34C50']
+
+        try:
+            auto_rx_config["carto_api_key"] = config.get(
+                "web", "carto_api_key"
+            )
+        except Exception as e:
+            logging.debug(
+                "Config - Missing carto_api_key (new in 1.9.0), using default (none)"
+            )
+            auto_rx_config["carto_api_key"] = "none"
 
         # If we are being called as part of a unit test, just return the config now.
         if no_sdr_test:

--- a/auto_rx/autorx/static/js/leaflet-providers.js
+++ b/auto_rx/autorx/static/js/leaflet-providers.js
@@ -742,12 +742,13 @@
 			}
 		},
 		CartoDB: {
-			url: 'https://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}{r}.png',
+			url: 'https://{s}.basemaps.cartocdn.com/{variant}/{z}/{x}/{y}{r}.png?key={key}',
 			options: {
 				attribution: '{attribution.OpenStreetMap} &copy; <a href="https://carto.com/attributions">CARTO</a>',
 				subdomains: 'abcd',
-				maxZoom: 19,
-				variant: 'light_all'
+				maxZoom: 20,
+				variant: 'light_all',
+				key: '<insert your API key here>',
 			},
 			variants: {
 				Positron: 'light_all',

--- a/auto_rx/autorx/templates/historical.html
+++ b/auto_rx/autorx/templates/historical.html
@@ -1008,10 +1008,10 @@
 
             // List of available map layers.
             var Mapnik = L.tileLayer.provider("OpenStreetMap.Mapnik", {edgeBufferTiles: 2});
-            var DarkMatter = L.tileLayer.provider("CartoDB.DarkMatter", {edgeBufferTiles: 2});
+            var DarkMatter = L.tileLayer.provider("CartoDB.DarkMatter", {edgeBufferTiles: 2, key: autorx_config["carto_api_key"]});
             var Terrain = L.tileLayer.provider("Stamen.Terrain", {edgeBufferTiles: 2});
             var WorldImagery = L.tileLayer.provider("Esri.WorldImagery", {edgeBufferTiles: 2});
-            var Voyager = L.tileLayer.provider("CartoDB.Voyager", {edgeBufferTiles: 2});
+            var Voyager = L.tileLayer.provider("CartoDB.Voyager", {edgeBufferTiles: 2, key: autorx_config["carto_api_key"]});
             var OpenTopoMap = L.tileLayer.provider("OpenTopoMap", {edgeBufferTiles: 2});
             
             // Add maps to baseMaps.

--- a/auto_rx/autorx/templates/index.html
+++ b/auto_rx/autorx/templates/index.html
@@ -238,10 +238,10 @@
 
             // List of available map layers.
             var Mapnik = L.tileLayer.provider("OpenStreetMap.Mapnik", {edgeBufferTiles: 2});
-            var DarkMatter = L.tileLayer.provider("CartoDB.DarkMatter", {edgeBufferTiles: 2});
+            var DarkMatter = L.tileLayer.provider("CartoDB.DarkMatter", {edgeBufferTiles: 2, key: autorx_config["carto_api_key"]});
             var Terrain = L.tileLayer.provider("Stamen.Terrain", {edgeBufferTiles: 2});
             var WorldImagery = L.tileLayer.provider("Esri.WorldImagery", {edgeBufferTiles: 2});
-            var Voyager = L.tileLayer.provider("CartoDB.Voyager", {edgeBufferTiles: 2});
+            var Voyager = L.tileLayer.provider("CartoDB.Voyager", {edgeBufferTiles: 2, key: autorx_config["carto_api_key"]});
             var OpenTopoMap = L.tileLayer.provider("OpenTopoMap", {edgeBufferTiles: 2});
 
             // Add maps to baseMaps.

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -496,6 +496,12 @@ web_password = none
 # KML refresh rate
 kml_refresh_rate = 10
 
+# CARTO Maps API Key
+# To use the DarkMatter and Voyager map files, you need an API key from CARTO
+# You can request one here: https://carto.com/basemaps/apikey/
+# Where it asks for what domains you are using this on, just enter 'localhost'
+carto_api_key = none
+
 
 ##################
 # DEBUG SETTINGS #

--- a/auto_rx/station.cfg.example
+++ b/auto_rx/station.cfg.example
@@ -499,7 +499,8 @@ kml_refresh_rate = 10
 # CARTO Maps API Key
 # To use the DarkMatter and Voyager map files, you need an API key from CARTO
 # You can request one here: https://carto.com/basemaps/apikey/
-# Where it asks for what domains you are using this on, just enter 'localhost'
+# Where it asks for what domains you are using this on, just enter 'localhost'.
+# If you are accessing your auto_rx web interface from an external domain, add that too.
 carto_api_key = none
 
 

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -496,6 +496,12 @@ web_password = none
 # KML refresh rate
 kml_refresh_rate = 10
 
+# CARTO Maps API Key
+# To use the DarkMatter and Voyager map files, you need an API key from CARTO
+# You can request one here: https://carto.com/basemaps/apikey/
+# Where it asks for what domains you are using this on, just enter 'localhost'
+carto_api_key = none
+
 
 ##################
 # DEBUG SETTINGS #

--- a/auto_rx/station.cfg.example.network
+++ b/auto_rx/station.cfg.example.network
@@ -499,7 +499,8 @@ kml_refresh_rate = 10
 # CARTO Maps API Key
 # To use the DarkMatter and Voyager map files, you need an API key from CARTO
 # You can request one here: https://carto.com/basemaps/apikey/
-# Where it asks for what domains you are using this on, just enter 'localhost'
+# Where it asks for what domains you are using this on, just enter 'localhost'.
+# If you are accessing your auto_rx web interface from an external domain, add that too.
 carto_api_key = none
 
 


### PR DESCRIPTION
- Try and stop the APRS exporter from sending placeholder heading and speed data.
- Add a new config option to specify a carto API key, to make the Dark Matter and Voyager map layers not have an overlay.