### PR TITLE
Perform string formatting for log messages sent to SocketIO

### DIFF
--- a/auto_rx/autorx/web.py
+++ b/auto_rx/autorx/web.py
@@ -730,7 +730,7 @@ class WebHandler(logging.Handler):
             log_data = {
                 "level": record.levelname,
                 "timestamp": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-                "msg": record.msg,
+                "msg": self.format(record),
             }
             # Emit to all socket.io clients
             socketio.emit("log_event", log_data, namespace="/update_status")


### PR DESCRIPTION
Some log messages contain formatting placeholders when displayed in the web interface:

<img width="324" height="80" alt="Screenshot from 2026-09-04 13-48-07" src="https://github.com/user-attachments/assets/a19d12ec-f455-49e8-a23a-2dd8401589d9" />

This is because the unformatted log message is sent to SocketIO. Formatting the message with `self.format(record)` solves this problem:

<img width="347" height="126" alt="Screenshot from 2026-09-04 13-50-57" src="https://github.com/user-attachments/assets/f58e01c1-35cc-4688-b8cf-c47805aacfa9" />

